### PR TITLE
perf: enable incremental SSE streaming for faster message display

### DIFF
--- a/apps/mobile/src/api/sse-client.test.ts
+++ b/apps/mobile/src/api/sse-client.test.ts
@@ -1,4 +1,4 @@
-import { streamTurnEvents, parseSSEResponse } from './sse-client';
+import { streamTurnEvents, parseSSEResponse, parseSSEBuffer } from './sse-client';
 
 // Mock dependencies
 jest.mock('expo-constants', () => ({
@@ -9,18 +9,65 @@ jest.mock('@/services/device-id', () => ({
   getOrCreateDeviceId: jest.fn(() => Promise.resolve('test-device-123')),
 }));
 
-// Mock fetch globally
+// Mock expo/fetch
 const mockFetch = jest.fn();
-global.fetch = mockFetch;
+jest.mock('expo/fetch', () => ({
+  fetch: (...args: unknown[]) => mockFetch(...args),
+}));
 
-function createMockResponse(
-  body: string,
+/**
+ * Encode a string as a Uint8Array (simulates what ReadableStream delivers).
+ */
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+/**
+ * Create a ReadableStream that yields the given chunks sequentially.
+ * Each chunk simulates a network packet arriving from the server.
+ */
+function createChunkedStream(chunks: string[]): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(encode(chunks[index]));
+        index++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+/**
+ * Create a mock response with a ReadableStream body.
+ */
+function createStreamingResponse(
+  chunks: string[],
   options: { ok?: boolean; status?: number } = {},
 ): Response {
   const { ok = true, status = 200 } = options;
   return {
     ok,
     status,
+    body: createChunkedStream(chunks),
+    text: jest.fn(() => Promise.resolve(chunks.join(''))),
+  } as unknown as Response;
+}
+
+/**
+ * Create a mock error response (no streaming body needed).
+ */
+function createErrorResponse(
+  body: string,
+  options: { status?: number } = {},
+): Response {
+  const { status = 500 } = options;
+  return {
+    ok: false,
+    status,
+    body: null,
     text: jest.fn(() => Promise.resolve(body)),
   } as unknown as Response;
 }
@@ -29,13 +76,84 @@ function createMockResponse(
 async function collectEvents(
   conversationId: string,
   audioFormData: FormData,
+  signal?: AbortSignal,
 ): Promise<Array<{ type: string; data: unknown }>> {
   const events: Array<{ type: string; data: unknown }> = [];
-  for await (const event of streamTurnEvents(conversationId, audioFormData)) {
+  for await (const event of streamTurnEvents(conversationId, audioFormData, signal)) {
     events.push(event);
   }
   return events;
 }
+
+describe('parseSSEBuffer', () => {
+  it('parses a single complete event', () => {
+    const { events, remaining } = parseSSEBuffer('event: stt_result\ndata: {"text":"Hello"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'stt_result', data: { text: 'Hello' } });
+    expect(remaining).toBe('');
+  });
+
+  it('returns remaining buffer when no complete event exists', () => {
+    const { events, remaining } = parseSSEBuffer('event: stt_result\ndata: {"text":"partial');
+    expect(events).toHaveLength(0);
+    expect(remaining).toBe('event: stt_result\ndata: {"text":"partial');
+  });
+
+  it('returns empty remaining when buffer ends on event boundary', () => {
+    const { events, remaining } = parseSSEBuffer('event: stt_result\ndata: {"text":"Hello"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(remaining).toBe('');
+  });
+
+  it('handles consecutive empty blocks', () => {
+    const { events, remaining } = parseSSEBuffer('\n\n\n\nevent: stt_result\ndata: {"text":"Hello"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(remaining).toBe('');
+  });
+
+  it('parses multiple events and keeps remaining', () => {
+    const buffer =
+      'event: stt_result\ndata: {"text":"Hello"}\n\n' +
+      'event: ai_response_done\ndata: {"text":"Hi"}\n\n' +
+      'event: turn_complete\ndata: ';
+    const { events, remaining } = parseSSEBuffer(buffer);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.type)).toEqual(['stt_result', 'ai_response_done']);
+    expect(remaining).toBe('event: turn_complete\ndata: ');
+  });
+
+  it('handles \\r\\n line endings', () => {
+    const { events, remaining } = parseSSEBuffer('event: stt_result\r\ndata: {"text":"Hello"}\r\n\r\n');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'stt_result', data: { text: 'Hello' } });
+    expect(remaining).toBe('');
+  });
+
+  it('handles \\r line endings', () => {
+    const { events, remaining } = parseSSEBuffer('event: stt_result\rdata: {"text":"Hello"}\r\r');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'stt_result', data: { text: 'Hello' } });
+    expect(remaining).toBe('');
+  });
+
+  it('skips SSE comment lines', () => {
+    const { events } = parseSSEBuffer(': keep-alive\nevent: stt_result\ndata: {"text":"Hello"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('stt_result');
+  });
+
+  it('skips malformed JSON with dev warning', () => {
+    const { events } = parseSSEBuffer('event: stt_result\ndata: {bad}\n\nevent: turn_complete\ndata: {}\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('turn_complete');
+  });
+
+  it('returns empty events and empty remaining for empty buffer', () => {
+    const { events, remaining } = parseSSEBuffer('');
+    expect(events).toHaveLength(0);
+    expect(remaining).toBe('');
+  });
+});
 
 describe('parseSSEResponse', () => {
   it('parses a single event', () => {
@@ -87,19 +205,25 @@ describe('parseSSEResponse', () => {
   it('returns empty array for empty body', () => {
     expect(parseSSEResponse('')).toHaveLength(0);
   });
+
+  it('handles body without trailing double-newline', () => {
+    const body = 'event: stt_result\ndata: {"text":"Hello"}';
+    const events = parseSSEResponse(body);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'stt_result', data: { text: 'Hello' } });
+  });
 });
 
 describe('streamTurnEvents', () => {
   const mockFormData = new FormData();
-  mockFormData.append('audio', new Blob(['audio-data']));
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('yields stt_result event', async () => {
-    const body = 'event: stt_result\ndata: {"text":"Hello world"}\n\n';
-    mockFetch.mockResolvedValue(createMockResponse(body));
+  it('yields stt_result event from a single chunk', async () => {
+    const chunks = ['event: stt_result\ndata: {"text":"Hello world"}\n\n'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -110,34 +234,66 @@ describe('streamTurnEvents', () => {
     });
   });
 
-  it('yields ai_response_chunk events', async () => {
-    const body =
-      'event: ai_response_chunk\ndata: {"text":"Hi"}\n\n' +
-      'event: ai_response_chunk\ndata: {"text":" there"}\n\n';
-    mockFetch.mockResolvedValue(createMockResponse(body));
+  it('yields events incrementally across multiple chunks', async () => {
+    const chunks = [
+      'event: stt_result\ndata: {"text":"Hello"}\n\n',
+      'event: ai_response_done\ndata: {"text":"Hi there"}\n\n',
+      'event: turn_complete\ndata: {}\n\n',
+    ];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     const events = await collectEvents('conv-1', mockFormData);
 
-    expect(events).toHaveLength(2);
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.type)).toEqual([
+      'stt_result',
+      'ai_response_done',
+      'turn_complete',
+    ]);
+  });
+
+  it('handles event split across chunk boundaries', async () => {
+    const chunks = [
+      'event: stt_result\ndata: {"tex',
+      't":"Hello"}\n\n',
+    ];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
+
+    const events = await collectEvents('conv-1', mockFormData);
+
+    expect(events).toHaveLength(1);
     expect(events[0]).toEqual({
-      type: 'ai_response_chunk',
-      data: { text: 'Hi' },
-    });
-    expect(events[1]).toEqual({
-      type: 'ai_response_chunk',
-      data: { text: ' there' },
+      type: 'stt_result',
+      data: { text: 'Hello' },
     });
   });
 
-  it('yields all event types in a full conversation turn', async () => {
-    const body =
+  it('yields multiple events from a single chunk', async () => {
+    const chunks = [
       'event: stt_result\ndata: {"text":"Hello"}\n\n' +
       'event: ai_response_chunk\ndata: {"text":"Hi"}\n\n' +
-      'event: ai_response_done\ndata: {"text":"Hi there"}\n\n' +
-      'event: tts_audio_url\ndata: {"url":"http://audio.mp3"}\n\n' +
-      'event: correction_result\ndata: {"correctedText":"Hello","explanation":"ok","items":[]}\n\n' +
-      'event: turn_complete\ndata: {}\n\n';
-    mockFetch.mockResolvedValue(createMockResponse(body));
+      'event: ai_response_chunk\ndata: {"text":" there"}\n\n',
+    ];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
+
+    const events = await collectEvents('conv-1', mockFormData);
+
+    expect(events).toHaveLength(3);
+    expect(events[0].type).toBe('stt_result');
+    expect(events[1]).toEqual({ type: 'ai_response_chunk', data: { text: 'Hi' } });
+    expect(events[2]).toEqual({ type: 'ai_response_chunk', data: { text: ' there' } });
+  });
+
+  it('yields all event types in a full conversation turn', async () => {
+    const chunks = [
+      'event: stt_result\ndata: {"text":"Hello"}\n\n',
+      'event: ai_response_chunk\ndata: {"text":"Hi"}\n\n',
+      'event: ai_response_done\ndata: {"text":"Hi there"}\n\n',
+      'event: tts_audio_url\ndata: {"url":"http://audio.mp3"}\n\n',
+      'event: correction_result\ndata: {"correctedText":"Hello","explanation":"ok","items":[]}\n\n',
+      'event: turn_complete\ndata: {}\n\n',
+    ];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -156,7 +312,7 @@ describe('streamTurnEvents', () => {
     const errorBody = JSON.stringify({
       error: { message: 'Internal error' },
     });
-    mockFetch.mockResolvedValue(createMockResponse(errorBody, { ok: false, status: 500 }));
+    mockFetch.mockResolvedValue(createErrorResponse(errorBody, { status: 500 }));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -169,7 +325,7 @@ describe('streamTurnEvents', () => {
 
   it('yields error with detail field from validation error', async () => {
     const errorBody = JSON.stringify({ detail: 'Validation failed' });
-    mockFetch.mockResolvedValue(createMockResponse(errorBody, { ok: false, status: 422 }));
+    mockFetch.mockResolvedValue(createErrorResponse(errorBody, { status: 422 }));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -181,7 +337,7 @@ describe('streamTurnEvents', () => {
   });
 
   it('yields default error when body is not JSON', async () => {
-    mockFetch.mockResolvedValue(createMockResponse('Server Error', { ok: false, status: 500 }));
+    mockFetch.mockResolvedValue(createErrorResponse('Server Error', { status: 500 }));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -193,7 +349,8 @@ describe('streamTurnEvents', () => {
   });
 
   it('sends request to correct endpoint with correct headers', async () => {
-    mockFetch.mockResolvedValue(createMockResponse('event: turn_complete\ndata: {}\n\n'));
+    const chunks = ['event: turn_complete\ndata: {}\n\n'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     await collectEvents('conv-123', mockFormData);
 
@@ -206,8 +363,20 @@ describe('streamTurnEvents', () => {
     expect(options.body).toBeInstanceOf(FormData);
   });
 
-  it('handles empty response', async () => {
-    mockFetch.mockResolvedValue(createMockResponse(''));
+  it('passes AbortSignal to fetch', async () => {
+    const chunks = ['event: turn_complete\ndata: {}\n\n'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
+
+    const controller = new AbortController();
+    await collectEvents('conv-1', mockFormData, controller.signal);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.signal).toBe(controller.signal);
+  });
+
+  it('handles empty stream', async () => {
+    const chunks = [''];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -215,8 +384,8 @@ describe('streamTurnEvents', () => {
   });
 
   it('yields error event from stream data', async () => {
-    const body = 'event: error\ndata: {"code":"STT_ERROR","message":"Speech recognition failed"}\n\n';
-    mockFetch.mockResolvedValue(createMockResponse(body));
+    const chunks = ['event: error\ndata: {"code":"STT_ERROR","message":"Speech recognition failed"}\n\n'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
 
     const events = await collectEvents('conv-1', mockFormData);
 
@@ -225,5 +394,86 @@ describe('streamTurnEvents', () => {
       type: 'error',
       data: { code: 'STT_ERROR', message: 'Speech recognition failed' },
     });
+  });
+
+  it('falls back to text() when response.body is null', async () => {
+    const body = 'event: stt_result\ndata: {"text":"Hello"}\n\nevent: turn_complete\ndata: {}\n\n';
+    const response = {
+      ok: true,
+      status: 200,
+      body: null,
+      text: jest.fn(() => Promise.resolve(body)),
+    } as unknown as Response;
+    mockFetch.mockResolvedValue(response);
+
+    const events = await collectEvents('conv-1', mockFormData);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('stt_result');
+    expect(events[1].type).toBe('turn_complete');
+  });
+
+  it('handles remaining buffer after stream ends', async () => {
+    const chunks = ['event: stt_result\ndata: {"text":"Hello"}'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
+
+    const events = await collectEvents('conv-1', mockFormData);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'stt_result',
+      data: { text: 'Hello' },
+    });
+  });
+
+  it('propagates fetch network errors to the consumer', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Network request failed'));
+
+    await expect(collectEvents('conv-1', mockFormData)).rejects.toThrow('Network request failed');
+  });
+
+  it('releases reader lock when stream errors mid-read', async () => {
+    let callCount = 0;
+    const mockReleaseLock = jest.fn();
+    const mockReader = {
+      read: jest.fn(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            done: false,
+            value: encode('event: stt_result\ndata: {"text":"Hello"}\n\n'),
+          });
+        }
+        return Promise.reject(new Error('Connection reset'));
+      }),
+      releaseLock: mockReleaseLock,
+    };
+
+    const response = {
+      ok: true,
+      status: 200,
+      body: { getReader: () => mockReader },
+    } as unknown as Response;
+    mockFetch.mockResolvedValue(response);
+
+    const events: Array<{ type: string; data: unknown }> = [];
+    await expect(async () => {
+      for await (const event of streamTurnEvents('conv-1', mockFormData)) {
+        events.push(event);
+      }
+    }).rejects.toThrow('Connection reset');
+
+    expect(events).toHaveLength(1);
+    expect(mockReleaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('encodes conversationId in URL to prevent path traversal', async () => {
+    const chunks = ['event: turn_complete\ndata: {}\n\n'];
+    mockFetch.mockResolvedValue(createStreamingResponse(chunks));
+
+    await collectEvents('../../admin', mockFormData);
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test-api/api/conversations/..%2F..%2Fadmin/turns');
   });
 });

--- a/apps/mobile/src/api/sse-client.ts
+++ b/apps/mobile/src/api/sse-client.ts
@@ -1,66 +1,86 @@
+import { fetch } from 'expo/fetch';
 import Constants from 'expo-constants';
 import { getOrCreateDeviceId } from '@/services/device-id';
 import type { TurnEvent } from '@/types/api';
 
 const API_BASE_URL = Constants.expoConfig?.extra?.apiBaseUrl ?? 'http://localhost:8000';
 
+// Maximum buffer size (1 MB) to prevent memory exhaustion from malformed streams
+const MAX_BUFFER_SIZE = 1024 * 1024;
+
 // Parse a single SSE line into its field type and value
 function parseSSELine(line: string): { event?: string; data?: string } {
+  if (line.startsWith(':')) return {}; // SSE comment (keep-alive)
   if (line.startsWith('event: ')) return { event: line.slice(7) };
   if (line.startsWith('data: ')) return { data: line.slice(6) };
   return {};
 }
 
 /**
- * Parse a complete SSE response body into an array of TurnEvent objects.
+ * Parse complete SSE event blocks from a buffer and return parsed events
+ * along with the remaining incomplete buffer.
  */
-export function parseSSEResponse(body: string): TurnEvent[] {
+export function parseSSEBuffer(buffer: string): { events: TurnEvent[]; remaining: string } {
   const events: TurnEvent[] = [];
-  const lines = body.split('\n');
-  let currentEvent = '';
+  // Normalize \r\n and \r to \n (per SSE spec)
+  const normalized = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  // Split on double-newline (SSE event boundary)
+  const blocks = normalized.split('\n\n');
+  // Last element may be incomplete — keep it as remaining buffer
+  const remaining = blocks.pop() ?? '';
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === '') {
-      // Empty line signals end of an SSE event block
-      currentEvent = '';
-      continue;
-    }
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (trimmed === '') continue;
 
-    const parsed = parseSSELine(trimmed);
-    if (parsed.event) {
-      currentEvent = parsed.event;
-    }
-    if (parsed.data && currentEvent) {
-      try {
-        const data = JSON.parse(parsed.data);
-        events.push({ type: currentEvent, data } as TurnEvent);
-      } catch {
-        // Skip malformed JSON lines
+    let currentEvent = '';
+    for (const line of trimmed.split('\n')) {
+      const parsed = parseSSELine(line.trim());
+      if (parsed.event) {
+        currentEvent = parsed.event;
+      }
+      if (parsed.data && currentEvent) {
+        try {
+          const data = JSON.parse(parsed.data);
+          events.push({ type: currentEvent, data } as TurnEvent);
+        } catch {
+          if (__DEV__) {
+            console.warn(`[SSE] Skipping malformed JSON for event "${currentEvent}":`, parsed.data);
+          }
+        }
       }
     }
   }
 
+  return { events, remaining };
+}
+
+/**
+ * Parse a complete SSE response body into an array of TurnEvent objects.
+ */
+export function parseSSEResponse(body: string): TurnEvent[] {
+  // Ensure the body ends with a double-newline so parseSSEBuffer
+  // treats the entire content as complete events.
+  const normalized = body.endsWith('\n\n') ? body : body + '\n\n';
+  const { events } = parseSSEBuffer(normalized);
   return events;
 }
 
 /**
  * Send audio and receive turn events from the backend SSE endpoint.
  *
- * React Native does not support ReadableStream on fetch responses,
- * and XHR onprogress/responseText is unreliable for incremental streaming.
- * This implementation waits for the full SSE response, then yields all
- * parsed events. The UI will update once the backend completes processing.
- *
- * TODO: Add true streaming support via a native SSE module or polyfill
- * for real-time event delivery (ai_response_chunk, tts_audio_url, etc.).
+ * Uses expo/fetch which supports ReadableStream on response bodies,
+ * enabling incremental SSE event delivery. Events are yielded as soon
+ * as they arrive from the backend (e.g. stt_result after STT completes)
+ * rather than waiting for the entire response to finish.
  */
 export async function* streamTurnEvents(
   conversationId: string,
   audioFormData: FormData,
+  signal?: AbortSignal,
 ): AsyncGenerator<TurnEvent> {
   const deviceId = await getOrCreateDeviceId();
-  const url = `${API_BASE_URL}/api/conversations/${conversationId}/turns`;
+  const url = `${API_BASE_URL}/api/conversations/${encodeURIComponent(conversationId)}/turns`;
 
   const response = await fetch(url, {
     method: 'POST',
@@ -69,6 +89,7 @@ export async function* streamTurnEvents(
       'Accept': 'text/event-stream',
     },
     body: audioFormData,
+    signal,
   });
 
   if (!response.ok) {
@@ -79,7 +100,8 @@ export async function* streamTurnEvents(
       ?? (body as Record<string, string> | null)?.detail
       ?? `Stream request failed (HTTP ${response.status})`;
     if (__DEV__) {
-      console.warn(`[SSE] Stream error HTTP ${response.status}: ${bodyText}`);
+      const truncated = bodyText.length > 200 ? bodyText.slice(0, 200) + '...' : bodyText;
+      console.warn(`[SSE] Stream error HTTP ${response.status}: ${truncated}`);
     }
     yield {
       type: 'error',
@@ -88,16 +110,54 @@ export async function* streamTurnEvents(
     return;
   }
 
-  // Read the full response body (all SSE events at once)
-  const bodyText = await response.text();
-
-  if (__DEV__) {
-    console.log(`[SSE] Received ${bodyText.length} bytes: ${bodyText.substring(0, 200)}`);
+  // Use ReadableStream for incremental reading (expo/fetch supports this)
+  if (!response.body) {
+    // Fallback: read full body if stream is not available
+    const bodyText = await response.text();
+    const events = parseSSEResponse(bodyText);
+    for (const event of events) {
+      yield event;
+    }
+    return;
   }
 
-  // Parse and yield all SSE events
-  const events = parseSSEResponse(bodyText);
-  for (const event of events) {
-    yield event;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      if (signal?.aborted) break;
+
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      if (buffer.length > MAX_BUFFER_SIZE) {
+        yield {
+          type: 'error',
+          data: { code: 'BUFFER_OVERFLOW', message: 'Stream buffer exceeded maximum size' },
+        };
+        return;
+      }
+
+      const { events, remaining } = parseSSEBuffer(buffer);
+      buffer = remaining;
+
+      for (const event of events) {
+        yield event;
+      }
+    }
+
+    // Process any remaining data in the buffer after stream ends
+    if (buffer.trim()) {
+      const { events } = parseSSEBuffer(buffer + '\n\n');
+      for (const event of events) {
+        yield event;
+      }
+    }
+  } finally {
+    reader.releaseLock();
   }
 }

--- a/apps/mobile/src/features/talk/hooks/useAudioRecording.test.ts
+++ b/apps/mobile/src/features/talk/hooks/useAudioRecording.test.ts
@@ -1,41 +1,51 @@
 import { buildAudioFormData } from './useAudioRecording';
 
+// Mock expo-file-system/next File class
+const mockBlob = new Blob(['test'], { type: 'audio/mp4' });
+const mockBlobFn = jest.fn().mockReturnValue(mockBlob);
+
+jest.mock('expo-file-system/next', () => ({
+  File: jest.fn().mockImplementation((uri: string) => ({
+    blob: mockBlobFn,
+    name: uri.split('/').pop() ?? 'audio.m4a',
+  })),
+}));
+
 describe('buildAudioFormData', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('creates a FormData with an audio field', () => {
     const formData = buildAudioFormData('file:///path/to/audio.m4a');
 
-    // FormData.append should have been called
     expect(formData).toBeInstanceOf(FormData);
   });
 
-  it('appends the audio field with correct structure', () => {
+  it('creates an ExpoFile from the given URI', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { File: MockFile } = require('expo-file-system/next');
+
+    buildAudioFormData('file:///recordings/test.m4a');
+
+    expect(MockFile).toHaveBeenCalledWith('file:///recordings/test.m4a');
+  });
+
+  it('appends the blob with the file name', () => {
     const appendSpy = jest.spyOn(FormData.prototype, 'append');
 
     buildAudioFormData('file:///recordings/test.m4a');
 
-    expect(appendSpy).toHaveBeenCalledWith('audio', expect.objectContaining({
-      uri: 'file:///recordings/test.m4a',
-      type: 'audio/mp4',
-    }));
+    expect(appendSpy).toHaveBeenCalledWith(
+      'audio',
+      mockBlob,
+      'test.m4a',
+    );
 
     appendSpy.mockRestore();
   });
 
-  it('sets the file name with correct extension', () => {
-    const appendSpy = jest.spyOn(FormData.prototype, 'append');
-
-    buildAudioFormData('file:///test.m4a');
-
-    const appendedValue = appendSpy.mock.calls[0][1] as unknown as {
-      name: string;
-    };
-    expect(appendedValue.name).toMatch(/audio\.m4a$/);
-
-    appendSpy.mockRestore();
-  });
-
-  it('handles different URI formats', () => {
-    // Should not throw for any valid URI string
+  it('handles different URI formats without error', () => {
     expect(() => buildAudioFormData('file:///a.m4a')).not.toThrow();
     expect(() =>
       buildAudioFormData('file:///long/path/to/recording.m4a'),

--- a/apps/mobile/src/features/talk/hooks/useAudioRecording.ts
+++ b/apps/mobile/src/features/talk/hooks/useAudioRecording.ts
@@ -2,6 +2,7 @@ import { useRef, useCallback } from 'react';
 import { Alert, Platform } from 'react-native';
 import { Audio } from 'expo-av';
 import { Asset } from 'expo-asset';
+import { File as ExpoFile } from 'expo-file-system/next';
 import { useAudioStore } from '@/stores/audio-store';
 import { isE2eMode } from '@/config/e2e';
 import { t } from '@/i18n';
@@ -156,14 +157,16 @@ export function useAudioRecording(): UseAudioRecordingReturn {
 
 /**
  * Build a FormData object from a recording file URI.
- * React Native's FormData accepts an object with uri/type/name for file uploads.
+ *
+ * Uses expo-file-system/next's File class which produces a native FileBlob
+ * compatible with expo/fetch. The React Native {uri, type, name} pattern
+ * only works with native fetch but fails with expo/fetch, and JS-layer
+ * Blob objects (via atob + Uint8Array) are not serializable by expo/fetch's
+ * native implementation either.
  */
 export function buildAudioFormData(uri: string): FormData {
+  const file = new ExpoFile(uri);
   const formData = new FormData();
-  formData.append('audio', {
-    uri,
-    type: 'audio/mp4',
-    name: 'audio.m4a',
-  } as unknown as Blob);
+  formData.append('audio', file.blob(), file.name);
   return formData;
 }


### PR DESCRIPTION
## Summary

- Replace batch SSE reading (`response.text()`) with `expo/fetch` `ReadableStream` to deliver SSE events incrementally as they arrive from the backend
- User messages now appear ~1-2s after sending (STT completion) instead of ~5-8s (entire pipeline completion)
- Switch `buildAudioFormData` from React Native's `{uri, type, name}` pattern to `expo-file-system/next` `File` class, which produces native `FileBlob` compatible with `expo/fetch`

### Key changes

| File | Change |
|---|---|
| `sse-client.ts` | `expo/fetch` + `ReadableStream` incremental parsing, `parseSSEBuffer()`, AbortSignal support, 1MB buffer limit, `encodeURIComponent` on conversationId |
| `sse-client.test.ts` | Streaming mock infrastructure (`createChunkedStream`), 10 new `parseSSEBuffer` tests, updated `streamTurnEvents` tests for streaming |
| `useAudioRecording.ts` | `buildAudioFormData` uses `expo-file-system/next` `File` class for `expo/fetch` compatibility |
| `useAudioRecording.test.ts` | Updated mocks for `ExpoFile` class |

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 171 unit tests pass (`npx jest`)
- [x] iOS E2E `voice-conversation.yaml` — all steps COMPLETED
- [x] Android E2E `voice-conversation.yaml` — all steps COMPLETED

🤖 Generated with [Claude Code](https://claude.com/claude-code)