### PR TITLE
chore: define platform support versions for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ coto/
 
 ## Getting Started
 
+### Platform Support
+
+| Platform | Min Version | Target Version | Coverage |
+|---|---|---|---|
+| iOS | 16.0 | 18 | ~98% |
+| Android | API 29 (Android 10) | API 35 (Android 15) | ~90% |
+
 ### Prerequisites
 
 - Python 3.12+

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -11,12 +11,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ios: {
     bundleIdentifier: 'com.coto.app',
     supportsTablet: false,
+    deploymentTarget: '16.0',
   },
   android: {
     package: 'com.coto.app',
     adaptiveIcon: {
       backgroundColor: '#ffffff',
     },
+    minSdkVersion: 29,
+    targetSdkVersion: 35,
   },
   plugins: [
     'expo-secure-store',


### PR DESCRIPTION
## Summary
- Set iOS deployment target to 16.0 (`deploymentTarget` in `app.config.ts`)
- Set Android min SDK to 29 / target SDK to 35 (`minSdkVersion`, `targetSdkVersion` in `app.config.ts`)
- Add platform support table to README.md

## Test plan
- [ ] Verify `npx expo export` succeeds with new config
- [ ] Verify iOS build targets iOS 16+ (`npx expo run:ios`)
- [ ] Verify Android build uses API 29 min / API 35 target (`npx expo run:android`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)