### PR TITLE
fix: rename Coto to Coyo and fix CI deploy

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -55,6 +55,8 @@ jobs:
           cd apps/api && alembic upgrade head
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REDIS_URL: "redis://localhost:6379"
+          OPENAI_API_KEY: "sk-dummy-for-migrations"
 
       # Deploy to Cloud Run
       - name: Deploy to Cloud Run


### PR DESCRIPTION
## Summary
- Rename Coto to Coyo across all deployment configs (GCP project, Cloud Run, GCS, Artifact Registry, Bundle ID, EAS)
- Add missing dummy `REDIS_URL` / `OPENAI_API_KEY` env vars for CI migration step
- Add `--attribute-condition` to WIF provider setup
- Update DEPLOY.md with actual repository name `h-aoki1623/coyo`

## Test plan
- [x] Cloud Run deploy succeeded (health check OK)
- [x] iOS preview build succeeded and app verified
- [ ] GitHub Actions deploy workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)