### PR TITLE
ci: skip deploy when only mobile files changed

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -14,13 +14,32 @@ env:
   IMAGE_NAME: coyo-api
 
 jobs:
-  deploy:
-    name: Build & Deploy to Cloud Run
+  changes:
+    name: Detect backend changes
     runs-on: ubuntu-latest
-    # Only deploy if CI passed (skip check for manual dispatch)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/api/**'
+              - 'docker-compose.yml'
+              - '.github/workflows/deploy-api.yml'
+
+  deploy:
+    name: Build & Deploy to Cloud Run
+    needs: changes
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.backend == 'true'
     permissions:
       contents: read
       id-token: write  # Required for Workload Identity Federation


### PR DESCRIPTION
## Summary
- Add a `changes` job to `deploy-api.yml` using `dorny/paths-filter@v3` to detect backend-related file changes
- Deploy job now only runs when changes are detected in `apps/api/**`, `docker-compose.yml`, or `.github/workflows/deploy-api.yml`
- Manual `workflow_dispatch` always triggers deploy regardless of file changes

## Test plan
- [ ] Merge a mobile-only change to `main` → verify Deploy API workflow is skipped
- [ ] Merge an `apps/api/` change to `main` → verify deploy runs normally
- [ ] Trigger manual "Run workflow" from GitHub Actions UI → verify deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)