### PR TITLE
fix: remove sensitive values from eas.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ apps/mobile/e2e/screenshots/
 # === Google Play service account key ===
 apps/mobile/google-play-service-account.json
 
+# === EAS local overrides (contains secrets) ===
+apps/mobile/eas.local.json
+
 # === Claude ===
 .claude/

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -18,8 +18,7 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "APP_ENV": "staging",
-        "API_BASE_URL": "https://coyo-api-2e7utxhw3q-an.a.run.app"
+        "APP_ENV": "staging"
       },
       "ios": {
         "enterpriseProvisioning": "adhoc"
@@ -28,15 +27,13 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "APP_ENV": "production",
-        "API_BASE_URL": "https://coyo-api-2e7utxhw3q-an.a.run.app"
+        "APP_ENV": "production"
       }
     }
   },
   "submit": {
     "production": {
       "ios": {
-        "appleId": "aokin.skywalker.c1623@gmail.com",
         "ascAppId": "6760171388",
         "appleTeamId": "4535US4KHP"
       },

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -199,11 +199,46 @@ npx eas init
 # Update app.config.ts with the EAS project ID from the output above
 ```
 
-### 3.2 Update eas.json
+### 3.2 Configure EAS Secrets
 
-Edit `apps/mobile/eas.json` and replace placeholder values:
-- `API_BASE_URL` in the `production` profile → your Cloud Run service URL
-- Apple/Google credentials in `submit.production`
+Sensitive values (API URLs, Apple credentials) are NOT stored in `eas.json`.
+Set them as EAS Secrets so they are injected at build/submit time:
+
+```bash
+cd apps/mobile
+
+# API URL for preview and production builds
+eas secret:create --name API_BASE_URL --value "https://<your-cloud-run-url>" --scope project
+
+# Apple ID for App Store submission
+eas secret:create --name APPLE_ID --value "your-apple-id@example.com" --scope project
+```
+
+For **local development**, create `apps/mobile/eas.local.json` (gitignored) to override values:
+
+```json
+{
+  "build": {
+    "preview": {
+      "env": {
+        "API_BASE_URL": "https://<your-cloud-run-url>"
+      }
+    },
+    "production": {
+      "env": {
+        "API_BASE_URL": "https://<your-cloud-run-url>"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "your-apple-id@example.com"
+      }
+    }
+  }
+}
+```
 
 ### 3.3 Build for iOS
 


### PR DESCRIPTION
## Summary

- Remove `API_BASE_URL` and `appleId` (email address) from `eas.json` to prevent exposure in the public repository
- Add `eas.local.json` to `.gitignore` for local build/submit overrides
- Update `docs/DEPLOY.md` with EAS Secrets setup instructions and `eas.local.json` template

## Post-merge steps

1. Set up EAS Secrets:
   ```bash
   cd apps/mobile
   eas secret:create --name API_BASE_URL --value "https://coyo-api-2e7utxhw3q-an.a.run.app" --scope project
   eas secret:create --name APPLE_ID --value "<your-apple-id>" --scope project
   ```
2. Create `apps/mobile/eas.local.json` for local builds (see `docs/DEPLOY.md` section 3.2)

## Test plan

- [ ] Verify `eas build --platform ios --profile preview` succeeds with EAS Secrets configured
- [ ] Verify `eas submit --platform ios` succeeds with `eas.local.json` providing `appleId`
- [ ] Confirm `eas.local.json` is not tracked by git after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)