### PR TITLE
ci: introduce develop branch and fix deploy trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - 'apps/**'
       - '.github/workflows/ci.yml'
       - 'Makefile'
   push:
-    branches: [main]
+    branches: [develop]
     paths:
       - 'apps/**'
       - '.github/workflows/ci.yml'

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,10 +1,12 @@
 name: Deploy API
 
 on:
-  workflow_run:
-    workflows: ["CI"]
+  push:
     branches: [main]
-    types: [completed]
+    paths:
+      - 'apps/api/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/deploy-api.yml'
   workflow_dispatch:
 
 env:
@@ -14,32 +16,9 @@ env:
   IMAGE_NAME: coyo-api
 
 jobs:
-  changes:
-    name: Detect backend changes
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            backend:
-              - 'apps/api/**'
-              - 'docker-compose.yml'
-              - '.github/workflows/deploy-api.yml'
-
   deploy:
     name: Build & Deploy to Cloud Run
-    needs: changes
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.backend == 'true'
     permissions:
       contents: read
       id-token: write  # Required for Workload Identity Federation


### PR DESCRIPTION
## Summary

- Change CI target branch from `main` to `develop` so CI runs only on `develop` PRs/pushes
- Replace `workflow_run` trigger in `deploy-api.yml` with `push` + `paths` filter on `main`
- Remove redundant `changes` job (paths-filter) from deploy workflow since `push.paths` handles filtering
- Establishes `feature/*` → `develop` (CI validation) → `main` (production deploy) flow

## Flow after this change

| Branch | CI | Deploy |
|--------|-----|--------|
| `develop` | lint + test | None |
| `main` | None | Production (backend changes only) |
| `feature/*` etc. | On PR to develop | None |

## Test plan

- [ ] PR to `develop` triggers CI
- [ ] Push to `main` does NOT trigger CI
- [ ] `develop` → `main` merge with backend changes triggers deploy
- [ ] `develop` → `main` merge with mobile-only changes does NOT trigger deploy
- [ ] `workflow_dispatch` manual deploy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)