### PR TITLE
refactor: consolidate shared functions from run-dev.sh and run-e2e.sh into common.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,44 +45,46 @@ When backend API schemas change (Pydantic models in `apps/api/src/coyo/schemas/`
 
 ### Running E2E Tests
 
+E2E tests require the dev environment running in a separate terminal.
+
 ```bash
-make e2e           # All flows on both iOS and Android (sequential)
-make e2e-ios       # All flows on iOS Simulator only
-make e2e-android   # All flows on Android Emulator only
+# Step 1: Start dev environment (in terminal 1)
+make dev-ios       # or: make dev-android / make dev-both
+
+# Step 2: Run E2E tests (in terminal 2)
+make e2e-ios       # All flows on iOS Simulator
+make e2e-android   # All flows on Android Emulator
+make e2e           # All flows on both platforms (sequential)
 
 # Single flow (useful for debugging or iterating on one test)
 make e2e-ios FLOW=app-launch.yaml
 make e2e-android FLOW=navigate-to-history.yaml
-
-# Skip native build (app already installed from a previous run)
-make e2e-ios SKIP_BUILD=1
-make e2e-ios SKIP_BUILD=1 FLOW=app-launch.yaml
 ```
 
 ### Prerequisites
 
+- **Dev environment running**: `make dev-ios` / `make dev-android` (handles Docker, backend, Metro, device boot, and app build)
 - **Maestro CLI**: `curl -Ls "https://get.maestro.mobile.dev" | bash`
-- **iOS**: Boot a simulator — `xcrun simctl boot "iPhone 16 Pro"`
-- **Android**: Start an emulator from Android Studio or `emulator -avd <name>`
-- **Docker**: Required for Postgres + Redis (`docker compose up -d`)
-- **Backend venv**: `apps/api/.venv` must exist with dependencies installed
 
-### What the script does automatically
+### Script responsibilities
 
-1. Detects git worktree and sets up dependencies independently (copies `.env`, Firebase credentials; installs `node_modules` via `npm ci` and creates `.venv`)
-2. Sweeps rogue Maestro/Metro processes from previous runs or manual invocations
-3. Starts Docker (Postgres + Redis) if not running
-4. Runs database migrations
-5. Starts backend API (`uvicorn`) if not running — stops it on exit
-6. Builds and installs the app on the target device (unless `SKIP_BUILD=1`)
-7. Starts Metro and waits for JS bundle compilation to complete before launching the app
-8. Runs all Maestro test flows
-9. Cleans up Metro and backend on exit (including Ctrl+C / kill)
+**`run-dev.sh`** (started via `make dev-ios` / `make dev-android`):
+1. Starts Docker (Postgres + Redis)
+2. Starts backend API (`uvicorn`)
+3. Boots iOS Simulator / Android Emulator
+4. Builds and installs the app
+5. Starts Metro bundler (foreground)
+6. Cleans up all processes on Ctrl+C
+
+**`run-e2e.sh`** (started via `make e2e-ios` / `make e2e-android`):
+1. Validates dev environment is running (API, Metro, device, app)
+2. Sweeps rogue Maestro processes to avoid port conflicts
+3. Runs Maestro test flows with retry on failure
 
 ### Rules
 
 - NEVER use `optional: true` on assertions that validate API responses — E2E tests must verify real backend interactions
-- The `run-e2e.sh` script ensures the backend is running; do NOT skip this by running `maestro test` directly
 - NEVER run Maestro CLI commands manually (`maestro test`, `maestro hierarchy`, etc.) — rogue Maestro processes cause port conflicts and test failures. Always use `make e2e` / `make e2e-ios` / `make e2e-android` to run E2E tests
+- NEVER run `maestro test` directly without `make e2e-*` — the script validates the environment and handles cleanup
 - iOS and Android tests run sequentially (Maestro uses port 7001 for both platforms)
 - Test flows are in `apps/mobile/e2e/*.yaml`

--- a/Makefile
+++ b/Makefile
@@ -50,21 +50,21 @@ test-api:
 	cd apps/api && .venv/bin/pytest
 
 # E2E Tests (Maestro)
+# Requires: dev environment running in another terminal (make dev-ios / make dev-android)
 # Usage:
 #   make e2e                              # All flows on both platforms
 #   make e2e-ios                          # All flows on iOS
 #   make e2e-android                      # All flows on Android
 #   make e2e-ios FLOW=app-launch.yaml     # Single flow on iOS
 #   make e2e-android FLOW=app-launch.yaml # Single flow on Android
-#   make e2e-ios SKIP_BUILD=1             # Skip native build (app already installed)
 e2e:
-	cd apps/mobile && ./e2e/run-e2e.sh all $(if $(SKIP_BUILD),--skip-build) $(FLOW)
+	cd apps/mobile && ./e2e/run-e2e.sh all $(FLOW)
 
 e2e-ios:
-	cd apps/mobile && ./e2e/run-e2e.sh ios $(if $(SKIP_BUILD),--skip-build) $(FLOW)
+	cd apps/mobile && ./e2e/run-e2e.sh ios $(FLOW)
 
 e2e-android:
-	cd apps/mobile && ./e2e/run-e2e.sh android $(if $(SKIP_BUILD),--skip-build) $(FLOW)
+	cd apps/mobile && ./e2e/run-e2e.sh android $(FLOW)
 
 # Database Migrations
 migrate:

--- a/apps/mobile/e2e/run-e2e.sh
+++ b/apps/mobile/e2e/run-e2e.sh
@@ -1,87 +1,56 @@
 #!/usr/bin/env bash
-# run-e2e.sh — Build, install, and run Maestro E2E tests on iOS/Android
+# run-e2e.sh — Run Maestro E2E tests on iOS/Android
 #
 # Usage:
-#   ./e2e/run-e2e.sh ios                        # Run all flows on iOS Simulator
-#   ./e2e/run-e2e.sh android                    # Run all flows on Android Emulator
-#   ./e2e/run-e2e.sh all                        # Run all flows on both (iOS, then Android)
-#   ./e2e/run-e2e.sh ios app-launch.yaml        # Run a single flow on iOS
-#   ./e2e/run-e2e.sh android navigate-to-history.yaml  # Run a single flow on Android
-#   ./e2e/run-e2e.sh ios --skip-build           # Skip native build (app already installed)
+#   ./e2e/run-e2e.sh ios                               # Run all flows on iOS Simulator
+#   ./e2e/run-e2e.sh android                            # Run all flows on Android Emulator
+#   ./e2e/run-e2e.sh all                                # Run all flows on both (iOS, then Android)
+#   ./e2e/run-e2e.sh ios app-launch.yaml                # Run a single flow on iOS
+#   ./e2e/run-e2e.sh android navigate-to-history.yaml   # Run a single flow on Android
 #
 # Prerequisites:
+#   - Dev environment running (make dev-ios / make dev-android / make dev-both)
 #   - Maestro CLI installed (maestro --version)
-#   - For iOS: a booted iOS Simulator (xcrun simctl list devices booted)
-#   - For Android: a running Android Emulator (adb devices)
 #
-# The script automatically:
-#   1. Detects git worktree and sets up dependencies (copies .env, credentials,
-#      installs node_modules and .venv independently)
-#   2. Validates prerequisites (Maestro, devices, Docker, Python venv)
-#   3. Starts Docker (Postgres + Redis) and backend API if not running
-#   4. Kills stale Maestro driver processes to avoid port conflicts
-#   5. Builds and installs the app via `npx expo run:*` (unless --skip-build)
-#   6. Ensures Maestro driver APKs are installed (Android)
-#   7. Sets up adb reverse port forwarding (Android)
-#   8. Runs all Maestro flows in the e2e/ directory
-#   9. Reports results
+# The dev environment (run-dev.sh) handles:
+#   - Docker (Postgres + Redis)
+#   - Backend API
+#   - Metro bundler
+#   - iOS Simulator / Android Emulator boot
+#   - App build and install
+#
+# This script only:
+#   1. Validates the dev environment is running (API, Metro, device, app)
+#   2. Sweeps rogue Maestro processes to avoid port conflicts
+#   3. Ensures Maestro driver APKs are installed (Android)
+#   4. Runs Maestro test flows with retry on failure
+#   5. Reports results
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$MOBILE_DIR/../.." && pwd)"
-# Main repo root (overridden if in a worktree)
-_MAIN_REPO_ROOT="$REPO_ROOT"
-# Docker Compose project name (consistent across main repo and worktrees)
-_COMPOSE_PROJECT="$(basename "$REPO_ROOT")"
 API_DIR="$REPO_ROOT/apps/api"
 E2E_DIR="$SCRIPT_DIR"
 SCREENSHOTS_DIR="$E2E_DIR/screenshots"
 
-API_PORT=8000
-API_HEALTH_URL="http://localhost:${API_PORT}/health"
+# Load shared functions
+source "$REPO_ROOT/scripts/lib/common.sh"
+init_log "[e2e]"
+init_worktree
+
 MAESTRO_PORT=7001
 MAESTRO_TIMEOUT=300  # 5 minutes (seconds) per maestro test invocation
 
 # Enable E2E mode: bypasses microphone recording with test audio file
 export E2E_MODE=true
 
-# Track whether we started the backend/Metro (for cleanup)
-_API_STARTED_BY_SCRIPT=false
-_METRO_PID=""
-_SKIP_BUILD=false
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-NC='\033[0m' # No Color
-
-log()  { echo -e "${GREEN}[e2e]${NC} $*"; }
-warn() { echo -e "${YELLOW}[e2e]${NC} $*"; }
-err()  { echo -e "${RED}[e2e]${NC} $*" >&2; }
-
 # ===========================================================================
-# Worktree support
+# Environment validation
 # ===========================================================================
 
-# Source the shared worktree setup script. It detects if we're in a worktree
-# and copies .env, credentials, installs node_modules and .venv independently.
-# Exports: WORKTREE_MAIN_REPO, WORKTREE_COMPOSE_PROJECT
-source "$REPO_ROOT/scripts/setup-worktree.sh"
-
-ensure_worktree_deps() {
-  setup_worktree
-  _MAIN_REPO_ROOT="$WORKTREE_MAIN_REPO"
-  _COMPOSE_PROJECT="$WORKTREE_COMPOSE_PROJECT"
-}
-
-# ===========================================================================
-# Prerequisites
-# ===========================================================================
-
-check_prerequisites() {
+require_environment() {
   local target="$1"
   local errors=0
 
@@ -91,48 +60,35 @@ check_prerequisites() {
     errors=$((errors + 1))
   fi
 
-  # Docker daemon
-  if ! docker info &>/dev/null; then
-    log "Docker daemon not running. Attempting to start Docker Desktop..."
-    open -a Docker 2>/dev/null || true
-    local retries=30
-    while ! docker info &>/dev/null; do
-      retries=$((retries - 1))
-      if [[ $retries -le 0 ]]; then
-        err "Docker daemon did not start within 60 seconds."
-        errors=$((errors + 1))
-        break
-      fi
-      sleep 2
-    done
-    if docker info &>/dev/null; then
-      log "Docker Desktop started."
-    fi
+  # Backend API
+  if ! curl -sf --max-time 3 "$API_HEALTH_URL" > /dev/null 2>&1; then
+    err "Backend API is not running at $API_HEALTH_URL"
+    err "Start the dev environment first: make dev-ios / make dev-android"
+    errors=$((errors + 1))
   fi
 
-  # Python venv
-  if [[ ! -x "$API_DIR/.venv/bin/python" ]]; then
-    err "Python venv not found at $API_DIR/.venv"
-    err "Create it with: cd $API_DIR && python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'"
+  # Metro bundler
+  if ! curl -sf --max-time 2 "http://localhost:8081/status" > /dev/null 2>&1; then
+    err "Metro bundler is not running on port 8081"
+    err "Start the dev environment first: make dev-ios / make dev-android"
     errors=$((errors + 1))
-  else
-    # Verify venv is not broken (shebang references correct path)
-    local venv_python
-    venv_python=$("$API_DIR/.venv/bin/python" -c "import sys; print(sys.executable)" 2>/dev/null || true)
-    if [[ -z "$venv_python" ]]; then
-      err "Python venv is broken (possibly due to directory rename)."
-      err "Recreate it with: cd $API_DIR && python3 -m venv .venv --clear && .venv/bin/pip install -e '.[dev]'"
-      errors=$((errors + 1))
-    fi
   fi
 
   # iOS-specific
   if [[ "$target" == "ios" || "$target" == "all" ]]; then
     local udid
-    udid=$(get_ios_simulator_udid)
+    udid=$(get_booted_ios_udid)
     if [[ -z "$udid" ]]; then
-      err "No booted iOS Simulator found. Boot one with: xcrun simctl boot <device>"
+      err "No booted iOS Simulator found."
+      err "Start the dev environment first: make dev-ios"
       errors=$((errors + 1))
+    else
+      # Verify app is installed
+      if ! xcrun simctl listapps "$udid" 2>/dev/null | grep -q "to.coyo.app"; then
+        err "iOS app (to.coyo.app) not installed on simulator."
+        err "Start the dev environment first: make dev-ios"
+        errors=$((errors + 1))
+      fi
     fi
   fi
 
@@ -145,28 +101,18 @@ check_prerequisites() {
       local device_id
       device_id=$(get_android_emulator_id)
       if [[ -z "$device_id" ]]; then
-        err "No Android Emulator found. Start one from Android Studio or with: emulator -avd <name>"
+        err "No Android Emulator found."
+        err "Start the dev environment first: make dev-android"
         errors=$((errors + 1))
+      else
+        # Verify app is installed
+        if ! adb -s "$device_id" shell pm list packages 2>/dev/null | grep -q "to.coyo.app"; then
+          err "Android app (to.coyo.app) not installed on emulator."
+          err "Start the dev environment first: make dev-android"
+          errors=$((errors + 1))
+        fi
       fi
     fi
-  fi
-
-  # expo-dev-client (required for Metro connection on Android/iOS debug builds)
-  if ! grep -q '"expo-dev-client"' "$MOBILE_DIR/package.json"; then
-    err "expo-dev-client not found in package.json."
-    err "Install it with: cd $MOBILE_DIR && npx expo install expo-dev-client"
-    errors=$((errors + 1))
-  fi
-
-  # Expo dependency compatibility check
-  log "Checking Expo dependency compatibility..."
-  cd "$MOBILE_DIR"
-  local compat_output
-  compat_output=$(npx expo install --check 2>&1 || true)
-  if echo "$compat_output" | grep -qi "incompatible\|invalid"; then
-    warn "Some dependencies may be incompatible with the current Expo SDK:"
-    echo "$compat_output" | tail -5
-    warn "Run 'npx expo install --fix' to auto-fix."
   fi
 
   # Test audio fixtures (required for voice conversation E2E)
@@ -196,94 +142,12 @@ check_prerequisites() {
   fi
 
   if [[ $errors -gt 0 ]]; then
-    err "$errors prerequisite check(s) failed. Fix the above issues and retry."
+    err "$errors prerequisite check(s) failed."
+    err "Start the dev environment first: make dev-ios / make dev-android / make dev-both"
     exit 1
   fi
 
-  log "All prerequisites satisfied."
-}
-
-# ===========================================================================
-# Backend
-# ===========================================================================
-
-ensure_docker() {
-  log "Checking Docker services (Postgres + Redis)..."
-  if ! docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" ps --status running 2>/dev/null | grep -q "postgres"; then
-    log "Starting Docker services..."
-    docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" up -d
-    # Wait for Postgres to be ready
-    local retries=10
-    while ! docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" exec -T postgres pg_isready -U coyo -d coyo > /dev/null 2>&1; do
-      retries=$((retries - 1))
-      if [[ $retries -le 0 ]]; then
-        err "Postgres did not become ready in time."
-        exit 1
-      fi
-      sleep 2
-    done
-    log "Docker services are running."
-  else
-    log "Docker services already running."
-  fi
-}
-
-ensure_backend() {
-  log "Checking backend API at ${API_HEALTH_URL}..."
-  if curl -sf --max-time 3 "$API_HEALTH_URL" > /dev/null 2>&1; then
-    log "Backend API already running."
-    return
-  fi
-
-  # Docker must be running before the API
-  ensure_docker
-
-  # Run migrations
-  # When running in a worktree, the .venv editable install points to the
-  # main repo's src/. Override PYTHONPATH so the worktree's src/ takes priority.
-  log "Running database migrations..."
-  cd "$API_DIR"
-  PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/alembic upgrade head 2>&1 | tail -3
-
-  # Start uvicorn in the background
-  log "Starting backend API..."
-  cd "$API_DIR"
-  PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/uvicorn src.coyo.main:app --port "$API_PORT" &
-  local api_pid=$!
-  _API_STARTED_BY_SCRIPT=true
-
-  # Wait for API to be ready
-  local retries=15
-  while ! curl -sf --max-time 2 "$API_HEALTH_URL" > /dev/null 2>&1; do
-    retries=$((retries - 1))
-    if [[ $retries -le 0 ]]; then
-      err "Backend API did not start within 30 seconds."
-      kill "$api_pid" 2>/dev/null || true
-      exit 1
-    fi
-    sleep 2
-  done
-  log "Backend API is running (PID: $api_pid)."
-}
-
-cleanup() {
-  # Stop Metro if we started it
-  if [[ -n "$_METRO_PID" ]] && kill -0 "$_METRO_PID" 2>/dev/null; then
-    log "Stopping Metro bundler (PID: $_METRO_PID)..."
-    kill "$_METRO_PID" 2>/dev/null || true
-    sleep 1
-    kill -9 "$_METRO_PID" 2>/dev/null || true
-  fi
-
-  # Stop backend API if we started it
-  if [[ "$_API_STARTED_BY_SCRIPT" == "true" ]]; then
-    log "Stopping backend API started by this script..."
-    local pids
-    pids=$(lsof -ti :"$API_PORT" 2>/dev/null || true)
-    if [[ -n "$pids" ]]; then
-      echo "$pids" | xargs kill 2>/dev/null || true
-    fi
-  fi
+  log "Environment ready."
 }
 
 # ===========================================================================
@@ -303,7 +167,7 @@ run_with_timeout() {
   (
     sleep "$timeout_secs"
     if kill -0 "$cmd_pid" 2>/dev/null; then
-      echo -e "${YELLOW}[e2e]${NC} Command timed out after ${timeout_secs}s, killing PID $cmd_pid..."
+      warn "Command timed out after ${timeout_secs}s, killing PID $cmd_pid..."
       kill -9 "$cmd_pid" 2>/dev/null || true
     fi
   ) &
@@ -317,7 +181,7 @@ run_with_timeout() {
   kill "$watchdog_pid" 2>/dev/null || true
   wait "$watchdog_pid" 2>/dev/null || true
 
-  # Killed by SIGKILL (137) from our watchdog → return 124 (timeout convention)
+  # Killed by SIGKILL (137) from our watchdog -> return 124 (timeout convention)
   if [[ $exit_code -eq 137 ]]; then
     return 124
   fi
@@ -397,20 +261,22 @@ ensure_maestro_driver_apks() {
     return 1
   fi
 
-  # Extract APKs from maestro-client.jar
+  # Extract APKs from maestro-client.jar (run in subshell to avoid cd side effects)
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  cd "$tmp_dir"
-  jar xf "$maestro_lib/maestro-client.jar" maestro-server.apk maestro-app.apk 2>/dev/null
+  (
+    cd "$tmp_dir"
+    jar xf "$maestro_lib/maestro-client.jar" maestro-server.apk maestro-app.apk 2>/dev/null
+  )
 
-  if [[ ! -f maestro-server.apk ]] || [[ ! -f maestro-app.apk ]]; then
+  if [[ ! -f "$tmp_dir/maestro-server.apk" ]] || [[ ! -f "$tmp_dir/maestro-app.apk" ]]; then
     err "Failed to extract Maestro APKs from maestro-client.jar"
     rm -rf "$tmp_dir"
     return 1
   fi
 
-  adb -s "$device_id" install -r maestro-server.apk 2>&1 | tail -1
-  adb -s "$device_id" install -r maestro-app.apk 2>&1 | tail -1
+  adb -s "$device_id" install -r "$tmp_dir/maestro-server.apk" 2>&1 | tail -1
+  adb -s "$device_id" install -r "$tmp_dir/maestro-app.apk" 2>&1 | tail -1
 
   rm -rf "$tmp_dir"
   log "Maestro driver APKs installed."
@@ -431,52 +297,15 @@ start_maestro_driver() {
   log "Maestro driver ready on port ${MAESTRO_PORT}."
 }
 
-# ===========================================================================
-# Android: adb reverse
-# ===========================================================================
-
-# Set up reverse port forwarding so localhost:<port> on the emulator
-# reaches localhost:<port> on the host. This is required because the app
-# uses http://localhost:8000 as the API base URL.
-setup_adb_reverse() {
-  local device_id="$1"
-  adb -s "$device_id" reverse tcp:8081 tcp:8081 2>/dev/null || true
-  adb -s "$device_id" reverse tcp:${API_PORT} tcp:${API_PORT} 2>/dev/null || true
-}
-
-# Verify adb reverse is active. Building/installing an APK can clear it.
+# Verify adb reverse is active. Maestro operations can clear it.
 verify_adb_reverse() {
   local device_id="$1"
   local current
   current=$(adb -s "$device_id" reverse --list 2>/dev/null || true)
   if ! echo "$current" | grep -q "tcp:${API_PORT}"; then
-    warn "adb reverse was cleared (likely by APK install). Re-establishing..."
+    warn "adb reverse was cleared. Re-establishing..."
     setup_adb_reverse "$device_id"
   fi
-}
-
-# ===========================================================================
-# Device detection
-# ===========================================================================
-
-get_ios_simulator_udid() {
-  local udid
-  udid=$(xcrun simctl list devices booted -j 2>/dev/null \
-    | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for runtime, devices in data.get('devices', {}).items():
-    for d in devices:
-        if d.get('state') == 'Booted':
-            print(d['udid'])
-            sys.exit(0)
-sys.exit(1)
-" 2>/dev/null) || true
-  echo "$udid"
-}
-
-get_android_emulator_id() {
-  adb devices 2>/dev/null | grep -E "emulator-[0-9]+\s+device" | awk '{print $1}' | head -1
 }
 
 # ===========================================================================
@@ -489,108 +318,18 @@ run_ios() {
   cleanup_maestro
 
   local udid
-  udid=$(get_ios_simulator_udid)
-  if [[ -z "$udid" ]]; then
-    err "No booted iOS Simulator found. Boot one with: xcrun simctl boot <device>"
-    exit 1
-  fi
+  udid=$(get_booted_ios_udid)
   log "Using iOS Simulator: $udid"
 
-  if [[ "$_SKIP_BUILD" != "true" ]]; then
-    # Build and install (--no-bundler: build only, don't start Metro)
-    log "Building iOS app..."
-    cd "$MOBILE_DIR"
-
-    # Xcode 17 workaround: pre-generate FirebaseAuth-Swift.h
-    if [[ ! -f "ios/Pods/Headers/Public/FirebaseAuth/FirebaseAuth-Swift.h" ]]; then
-      if [[ ! -d "ios" ]]; then
-        log "Running expo prebuild..."
-        npx expo prebuild --platform ios --clean 2>&1 | tail -5
-      fi
-      if [[ -f "scripts/fix-firebase-swift-header.sh" ]]; then
-        log "Generating FirebaseAuth-Swift.h (Xcode 17 workaround)..."
-        bash scripts/fix-firebase-swift-header.sh
-      fi
-    fi
-
-    # Prebuild native project if needed
-    if [[ ! -d "ios" ]]; then
-      log "Running expo prebuild..."
-      npx expo prebuild --platform ios --clean 2>&1 | tail -5
-    fi
-
-    # Build with xcodebuild (expo run:ios fails on Xcode 17 beta due to
-    # devicectl JSON format changes that misidentify simulator as physical device)
-    log "Building with xcodebuild..."
-    xcodebuild \
-      -workspace ios/Coyo.xcworkspace \
-      -scheme Coyo \
-      -destination "platform=iOS Simulator,id=$udid" \
-      -configuration Debug \
-      build \
-      -quiet 2>&1 | tail -5 || true
-
-    # Find and install the built app
-    local app_path
-    app_path=$(find ~/Library/Developer/Xcode/DerivedData -name "Coyo.app" \
-      -path "*Debug-iphonesimulator*" -newer ios/Podfile 2>/dev/null | head -1)
-
-    if [[ -z "$app_path" ]]; then
-      err "Built Coyo.app not found in DerivedData."
-      exit 1
-    fi
-
-    log "Installing app from: $app_path"
-    xcrun simctl install "$udid" "$app_path"
-
-    # Verify installation
-    if ! xcrun simctl listapps "$udid" 2>/dev/null | grep -q "to.coyo.app"; then
-      err "iOS app not installed on simulator. Build may have failed."
-      exit 1
-    fi
-    log "iOS app installed successfully."
-  else
-    log "Skipping iOS build (--skip-build)."
-    if ! xcrun simctl listapps "$udid" 2>/dev/null | grep -q "to.coyo.app"; then
-      err "iOS app not installed on simulator. Cannot skip build."
-      exit 1
-    fi
-  fi
-
-  # Start Metro bundler in the background (--dev-client matches expo-dev-client URL scheme)
-  log "Starting Metro bundler..."
-  cd "$MOBILE_DIR"
-  npx expo start --dev-client --port 8081 > /tmp/metro-e2e.log 2>&1 &
-  local metro_pid=$!
-  _METRO_PID="$metro_pid"
-
-  # Phase 1: wait for Metro HTTP server to start (fast)
-  local retries=30
-  while ! curl -sf --max-time 2 "http://localhost:8081/status" > /dev/null 2>&1; do
-    retries=$((retries - 1))
-    if [[ $retries -le 0 ]]; then
-      err "Metro bundler did not start within 60 seconds."
-      kill "$metro_pid" 2>/dev/null || true
-      exit 1
-    fi
-    sleep 2
-  done
-  log "Metro HTTP server is up. Waiting for iOS bundle compilation..."
-
-  # Phase 2: wait for the JS bundle to finish compiling (slow on first run)
-  local bundle_retries=5
-  while ! curl -sf --max-time 120 \
+  # Verify Metro is serving iOS bundles
+  log "Verifying Metro bundle availability for iOS..."
+  if ! curl -sf --max-time 120 \
       "http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false" \
-      -o /dev/null 2>/dev/null; do
-    bundle_retries=$((bundle_retries - 1))
-    if [[ $bundle_retries -le 0 ]]; then
-      err "Metro iOS bundle did not compile within timeout."
-      kill "$metro_pid" 2>/dev/null || true
-      exit 1
-    fi
-    warn "Bundle not ready yet, retrying ($bundle_retries attempts left)..."
-  done
-  log "Metro bundler is ready — iOS bundle compiled (PID: $metro_pid)."
+      -o /dev/null 2>/dev/null; then
+    err "Metro is not serving iOS bundles. Check Metro bundler output."
+    exit 1
+  fi
+  log "Metro iOS bundle is ready."
 
   # Launch the app so it connects to Metro before Maestro takes over
   log "Launching app to connect to Metro..."
@@ -637,9 +376,6 @@ run_ios() {
     run_with_timeout "${MAESTRO_TIMEOUT}" maestro --platform ios --udid "$udid" test "$_FLOW_TARGET" || exit_code=$?
   fi
 
-  # Stop Metro
-  kill "$metro_pid" 2>/dev/null || true
-
   log "iOS E2E tests finished (exit code: $exit_code)"
   return $exit_code
 }
@@ -655,77 +391,25 @@ run_android() {
 
   local device_id
   device_id=$(get_android_emulator_id)
-  if [[ -z "$device_id" ]]; then
-    err "No Android Emulator found. Start one from Android Studio or with: emulator -avd <name>"
-    exit 1
-  fi
   log "Using Android Emulator: $device_id"
 
-  # Set up reverse port forwarding for Metro and API
+  # Ensure adb reverse is set up
   setup_adb_reverse "$device_id"
-
-  if [[ "$_SKIP_BUILD" != "true" ]]; then
-    # Build and install (--no-bundler: build only, don't start Metro)
-    log "Building Android app..."
-    cd "$MOBILE_DIR"
-    npx expo run:android --no-bundler 2>&1 | tail -5
-
-    # Verify installation
-    if ! adb -s "$device_id" shell pm list packages 2>/dev/null | grep -q "to.coyo.app"; then
-      err "Android app not installed on emulator. Build may have failed."
-      exit 1
-    fi
-    log "Android app installed successfully."
-  else
-    log "Skipping Android build (--skip-build)."
-    if ! adb -s "$device_id" shell pm list packages 2>/dev/null | grep -q "to.coyo.app"; then
-      err "Android app not installed on emulator. Cannot skip build."
-      exit 1
-    fi
-  fi
-
-  # Re-establish reverse port forwarding (build/install can clear adb state)
-  verify_adb_reverse "$device_id"
 
   # Ensure Maestro driver APKs are installed (may be missing after wipe-data)
   ensure_maestro_driver_apks "$device_id"
 
-  # Start Metro bundler in the background (--dev-client matches expo-dev-client URL scheme)
-  log "Starting Metro bundler..."
-  cd "$MOBILE_DIR"
-  npx expo start --dev-client --port 8081 > /tmp/metro-e2e-android.log 2>&1 &
-  local metro_pid=$!
-  _METRO_PID="$metro_pid"
-
-  # Phase 1: wait for Metro HTTP server to start (fast)
-  local retries=30
-  while ! curl -sf --max-time 2 "http://localhost:8081/status" > /dev/null 2>&1; do
-    retries=$((retries - 1))
-    if [[ $retries -le 0 ]]; then
-      err "Metro bundler did not start within 60 seconds."
-      kill "$metro_pid" 2>/dev/null || true
-      exit 1
-    fi
-    sleep 2
-  done
-  log "Metro HTTP server is up. Waiting for Android bundle compilation..."
-
-  # Phase 2: wait for the JS bundle to finish compiling (slow on first run)
-  local bundle_retries=5
-  while ! curl -sf --max-time 120 \
+  # Verify Metro is serving Android bundles
+  log "Verifying Metro bundle availability for Android..."
+  if ! curl -sf --max-time 120 \
       "http://localhost:8081/index.bundle?platform=android&dev=true&minify=false" \
-      -o /dev/null 2>/dev/null; do
-    bundle_retries=$((bundle_retries - 1))
-    if [[ $bundle_retries -le 0 ]]; then
-      err "Metro Android bundle did not compile within timeout."
-      kill "$metro_pid" 2>/dev/null || true
-      exit 1
-    fi
-    warn "Bundle not ready yet, retrying ($bundle_retries attempts left)..."
-  done
-  log "Metro bundler is ready — Android bundle compiled (PID: $metro_pid)."
+      -o /dev/null 2>/dev/null; then
+    err "Metro is not serving Android bundles. Check Metro bundler output."
+    exit 1
+  fi
+  log "Metro Android bundle is ready."
 
-  # Re-verify adb reverse after Metro start
+  # Re-verify adb reverse
   verify_adb_reverse "$device_id"
 
   # Launch the app so it connects to Metro before Maestro takes over
@@ -761,9 +445,6 @@ run_android() {
     run_with_timeout "${MAESTRO_TIMEOUT}" maestro --platform android --udid "$device_id" test "$_FLOW_TARGET" || exit_code=$?
   fi
 
-  # Stop Metro
-  kill "$metro_pid" 2>/dev/null || true
-
   log "Android E2E tests finished (exit code: $exit_code)"
   return $exit_code
 }
@@ -773,22 +454,18 @@ run_android() {
 # ===========================================================================
 
 usage() {
-  echo "Usage: $0 {ios|android|all} [--skip-build] [flow.yaml]"
+  echo "Usage: $0 {ios|android|all} [flow.yaml]"
   echo ""
   echo "  ios      Run E2E tests on iOS Simulator"
   echo "  android  Run E2E tests on Android Emulator"
   echo "  all      Run on both (iOS first, then Android)"
   echo ""
-  echo "Options:"
-  echo "  --skip-build  Skip native build+install (use already-installed app)"
-  echo ""
   echo "  Optional: specify a single flow file (e.g., app-launch.yaml)"
   echo "            to run only that flow instead of the full suite."
+  echo ""
+  echo "  Requires: dev environment running (make dev-ios / make dev-android)"
   exit 1
 }
-
-# Ensure cleanup on exit, Ctrl+C, or kill
-trap cleanup EXIT INT TERM
 
 if [[ $# -lt 1 ]]; then
   usage
@@ -803,14 +480,10 @@ case "$_TARGET" in
   *) usage ;;
 esac
 
-# Parse remaining args: [--skip-build] [flow.yaml]
+# Parse remaining args: [flow.yaml]
 _FLOW_TARGET=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --skip-build)
-      _SKIP_BUILD=true
-      shift
-      ;;
     -*)
       err "Unknown option: $1"
       usage
@@ -835,42 +508,11 @@ if [[ -z "$_FLOW_TARGET" ]]; then
   _FLOW_TARGET="$E2E_DIR/"
 fi
 
-# Symlink dependencies if running inside a git worktree
-ensure_worktree_deps
-
-# Validate all prerequisites upfront before doing any work
-check_prerequisites "$_TARGET"
-
-# Kill any existing Metro process on port 8081 to avoid "Use port 8082?" prompt
-kill_existing_metro() {
-  local pids
-  pids=$(lsof -ti :8081 2>/dev/null || true)
-  if [[ -z "$pids" ]]; then
-    return
-  fi
-
-  warn "Killing existing Metro process on port 8081 (PIDs: $pids)"
-  # Stage 1: graceful SIGTERM
-  echo "$pids" | xargs kill 2>/dev/null || true
-  sleep 2
-
-  # Stage 2: SIGKILL anything that didn't exit
-  local remaining
-  remaining=$(lsof -ti :8081 2>/dev/null || true)
-  if [[ -n "$remaining" ]]; then
-    warn "Metro did not exit after SIGTERM; force-killing (PIDs: $remaining)"
-    echo "$remaining" | xargs kill -9 2>/dev/null || true
-    sleep 1
-  fi
-}
-kill_existing_metro
+# Validate dev environment is running
+require_environment "$_TARGET"
 
 # Sweep any rogue Maestro processes started outside this script
-# (e.g., 'maestro hierarchy' run manually in another terminal)
 cleanup_maestro
-
-# Always ensure backend is running before E2E tests
-ensure_backend
 
 case "$_TARGET" in
   ios)
@@ -889,14 +531,14 @@ case "$_TARGET" in
     echo ""
     log "=== Summary ==="
     if [[ $ios_result -eq 0 ]]; then
-      log "iOS:     ${GREEN}PASSED${NC}"
+      log "iOS:     PASSED"
     else
-      err "iOS:     ${RED}FAILED${NC} (exit code: $ios_result)"
+      err "iOS:     FAILED (exit code: $ios_result)"
     fi
     if [[ $android_result -eq 0 ]]; then
-      log "Android: ${GREEN}PASSED${NC}"
+      log "Android: PASSED"
     else
-      err "Android: ${RED}FAILED${NC} (exit code: $android_result)"
+      err "Android: FAILED (exit code: $android_result)"
     fi
 
     [[ $ios_result -eq 0 && $android_result -eq 0 ]]

--- a/apps/mobile/run-dev.sh
+++ b/apps/mobile/run-dev.sh
@@ -27,42 +27,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MOBILE_DIR="$SCRIPT_DIR"
 REPO_ROOT="$(cd "$MOBILE_DIR/../.." && pwd)"
-# Main repo root (overridden if in a worktree)
-_MAIN_REPO_ROOT="$REPO_ROOT"
-# Docker Compose project name (consistent across main repo and worktrees)
-_COMPOSE_PROJECT="$(basename "$REPO_ROOT")"
 API_DIR="$REPO_ROOT/apps/api"
 
-API_PORT=8000
-API_HEALTH_URL="http://localhost:${API_PORT}/health"
+# Load shared functions
+source "$REPO_ROOT/scripts/lib/common.sh"
+init_log "[dev]"
+init_worktree
 
 # Track PIDs for cleanup
 _PIDS_TO_KILL=()
-_API_STARTED_BY_SCRIPT=false
-
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log()  { echo -e "${GREEN}[dev]${NC} $*"; }
-warn() { echo -e "${YELLOW}[dev]${NC} $*"; }
-err()  { echo -e "${RED}[dev]${NC} $*" >&2; }
-info() { echo -e "${CYAN}[dev]${NC} $*"; }
-
-# ===========================================================================
-# Worktree support
-# ===========================================================================
-
-# Source the shared worktree setup script. It detects if we're in a worktree
-# and copies .env, credentials, installs node_modules and .venv independently.
-# Exports: WORKTREE_MAIN_REPO, WORKTREE_COMPOSE_PROJECT
-source "$REPO_ROOT/scripts/setup-worktree.sh"
-setup_worktree
-_MAIN_REPO_ROOT="$WORKTREE_MAIN_REPO"
-_COMPOSE_PROJECT="$WORKTREE_COMPOSE_PROJECT"
 
 # ===========================================================================
 # Cleanup
@@ -82,7 +55,7 @@ cleanup() {
   fi
 
   # Stop backend if we started it
-  if [[ "$_API_STARTED_BY_SCRIPT" == "true" ]]; then
+  if [[ -n "$_BACKEND_PID" ]]; then
     log "Stopping backend API..."
     local pids
     pids=$(lsof -ti :"$API_PORT" 2>/dev/null || true)
@@ -97,184 +70,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # ===========================================================================
-# Metro
+# iOS: Build and install
 # ===========================================================================
-
-# Kill any existing Metro process on port 8081
-# (e.g. leftover from a previous session, build copy, or expo run:*)
-kill_existing_metro() {
-  local pids
-  pids=$(lsof -ti :8081 2>/dev/null || true)
-  if [[ -z "$pids" ]]; then
-    return
-  fi
-
-  warn "Killing existing Metro process on port 8081 (PIDs: $pids)"
-  # Stage 1: graceful SIGTERM
-  echo "$pids" | xargs kill 2>/dev/null || true
-  sleep 2
-
-  # Stage 2: SIGKILL anything that didn't exit
-  local remaining
-  remaining=$(lsof -ti :8081 2>/dev/null || true)
-  if [[ -n "$remaining" ]]; then
-    warn "Metro did not exit after SIGTERM; force-killing (PIDs: $remaining)"
-    echo "$remaining" | xargs kill -9 2>/dev/null || true
-    sleep 1
-  fi
-}
-
-# ===========================================================================
-# Docker
-# ===========================================================================
-
-ensure_docker() {
-  if docker info &>/dev/null; then
-    log "Docker daemon is running."
-  else
-    log "Starting Docker Desktop..."
-    open -a Docker 2>/dev/null || true
-    local retries=30
-    while ! docker info &>/dev/null; do
-      retries=$((retries - 1))
-      if [[ $retries -le 0 ]]; then
-        err "Docker did not start within 60 seconds."
-        exit 1
-      fi
-      sleep 2
-    done
-    log "Docker Desktop started."
-  fi
-
-  if docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" ps --status running 2>/dev/null | grep -q "postgres"; then
-    log "Docker services already running."
-  else
-    log "Starting Docker services (Postgres + Redis)..."
-    docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" up -d
-    local retries=10
-    while ! docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" exec -T postgres pg_isready -U coyo -d coyo > /dev/null 2>&1; do
-      retries=$((retries - 1))
-      if [[ $retries -le 0 ]]; then
-        err "Postgres did not become ready."
-        exit 1
-      fi
-      sleep 2
-    done
-    log "Docker services are running."
-  fi
-}
-
-# ===========================================================================
-# Backend
-# ===========================================================================
-
-ensure_backend() {
-  if curl -sf --max-time 3 "$API_HEALTH_URL" > /dev/null 2>&1; then
-    log "Backend API already running."
-    return
-  fi
-
-  ensure_docker
-
-  # Verify venv
-  if [[ ! -x "$API_DIR/.venv/bin/python" ]]; then
-    err "Python venv not found at $API_DIR/.venv"
-    err "Create it with: cd $API_DIR && python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'"
-    exit 1
-  fi
-
-  local venv_python
-  venv_python=$("$API_DIR/.venv/bin/python" -c "import sys; print(sys.executable)" 2>/dev/null || true)
-  if [[ -z "$venv_python" ]]; then
-    err "Python venv is broken. Recreate with: cd $API_DIR && python3 -m venv .venv --clear && .venv/bin/pip install -e '.[dev]'"
-    exit 1
-  fi
-
-  # Run migrations
-  # When running in a worktree, the .venv editable install points to the
-  # main repo's src/. Override PYTHONPATH so the worktree's src/ takes priority.
-  log "Running database migrations..."
-  cd "$API_DIR"
-  PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/alembic upgrade head 2>&1 | tail -3
-
-  # Start uvicorn in background
-  log "Starting backend API..."
-  cd "$API_DIR"
-  PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/uvicorn src.coyo.main:app --port "$API_PORT" &
-  local api_pid=$!
-  _PIDS_TO_KILL+=("$api_pid")
-  _API_STARTED_BY_SCRIPT=true
-
-  local retries=15
-  while ! curl -sf --max-time 2 "$API_HEALTH_URL" > /dev/null 2>&1; do
-    retries=$((retries - 1))
-    if [[ $retries -le 0 ]]; then
-      err "Backend API did not start within 30 seconds."
-      exit 1
-    fi
-    sleep 2
-  done
-  log "Backend API is running (PID: $api_pid)."
-}
-
-# ===========================================================================
-# iOS Simulator
-# ===========================================================================
-
-get_booted_ios_udid() {
-  xcrun simctl list devices booted -j 2>/dev/null \
-    | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for runtime, devices in data.get('devices', {}).items():
-    for d in devices:
-        if d.get('state') == 'Booted':
-            print(d['udid'])
-            sys.exit(0)
-sys.exit(1)
-" 2>/dev/null || true
-}
-
-boot_ios_simulator() {
-  local udid
-  udid=$(get_booted_ios_udid)
-  if [[ -n "$udid" ]]; then
-    log "iOS Simulator already booted: $udid"
-    return
-  fi
-
-  # Pick the first available iPhone simulator
-  local target_udid
-  target_udid=$(xcrun simctl list devices available -j 2>/dev/null \
-    | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for runtime, devices in sorted(data.get('devices', {}).items(), reverse=True):
-    for d in devices:
-        if d.get('isAvailable') and 'iPhone' in d.get('name', '') and 'Pro' in d.get('name', ''):
-            print(d['udid'])
-            sys.exit(0)
-# Fallback: any iPhone
-for runtime, devices in sorted(data.get('devices', {}).items(), reverse=True):
-    for d in devices:
-        if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
-            print(d['udid'])
-            sys.exit(0)
-sys.exit(1)
-" 2>/dev/null) || true
-
-  if [[ -z "$target_udid" ]]; then
-    err "No iPhone simulator found. Create one in Xcode > Window > Devices and Simulators."
-    exit 1
-  fi
-
-  log "Booting iOS Simulator ($target_udid)..."
-  xcrun simctl boot "$target_udid" 2>/dev/null || true
-  # Open Simulator.app to show the window
-  open -a Simulator 2>/dev/null || true
-  sleep 3
-  log "iOS Simulator booted."
-}
 
 run_ios() {
   boot_ios_simulator
@@ -300,7 +97,6 @@ run_ios() {
 
   # Build with xcodebuild (expo run:ios fails on Xcode 17 beta due to
   # devicectl JSON format changes that misidentify simulator as physical device)
-  # --no-bundler not needed: Metro is already running (started in Step 3).
   log "Building with xcodebuild..."
   xcodebuild \
     -workspace ios/Coyo.xcworkspace \
@@ -348,70 +144,15 @@ run_ios() {
 }
 
 # ===========================================================================
-# Android Emulator
+# Android: Build and install
 # ===========================================================================
-
-get_android_emulator_id() {
-  adb devices 2>/dev/null | grep -E "emulator-[0-9]+\s+device" | awk '{print $1}' | head -1 || true
-}
-
-boot_android_emulator() {
-  local device_id
-  device_id=$(get_android_emulator_id)
-  if [[ -n "$device_id" ]]; then
-    log "Android Emulator already running: $device_id"
-    return
-  fi
-
-  if ! command -v adb &>/dev/null; then
-    err "adb not found. Install Android SDK platform-tools."
-    exit 1
-  fi
-
-  # Find the first available AVD
-  local avd_name
-  avd_name=$("$ANDROID_HOME/emulator/emulator" -list-avds 2>/dev/null | head -1)
-  if [[ -z "$avd_name" ]]; then
-    err "No Android AVD found. Create one in Android Studio > Virtual Device Manager."
-    exit 1
-  fi
-
-  log "Starting Android Emulator ($avd_name)..."
-  "$ANDROID_HOME/emulator/emulator" -avd "$avd_name" -no-snapshot-load &>/dev/null &
-  _PIDS_TO_KILL+=("$!")
-
-  # Wait for emulator to boot
-  log "Waiting for emulator to boot..."
-  local retries=60
-  while true; do
-    device_id=$(get_android_emulator_id)
-    if [[ -n "$device_id" ]]; then
-      # Check if boot completed
-      local boot_status
-      boot_status=$(adb -s "$device_id" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
-      if [[ "$boot_status" == "1" ]]; then
-        break
-      fi
-    fi
-    retries=$((retries - 1))
-    if [[ $retries -le 0 ]]; then
-      err "Android Emulator did not boot within 120 seconds."
-      exit 1
-    fi
-    sleep 2
-  done
-  log "Android Emulator booted: $device_id"
-}
-
-setup_adb_reverse() {
-  local device_id="$1"
-  adb -s "$device_id" reverse tcp:8081 tcp:8081 2>/dev/null || true
-  adb -s "$device_id" reverse tcp:${API_PORT} tcp:${API_PORT} 2>/dev/null || true
-  log "adb reverse set up (ports 8081, ${API_PORT})."
-}
 
 run_android() {
   boot_android_emulator
+  if [[ -n "$_EMULATOR_PID" ]]; then
+    _PIDS_TO_KILL+=("$_EMULATOR_PID")
+  fi
+
   local device_id
   device_id=$(get_android_emulator_id)
 
@@ -459,7 +200,10 @@ echo ""
 kill_existing_metro
 
 # Step 2: Backend infrastructure
-ensure_backend
+ensure_backend || exit 1
+if [[ -n "$_BACKEND_PID" ]]; then
+  _PIDS_TO_KILL+=("$_BACKEND_PID")
+fi
 
 # Step 3: Start Metro in background BEFORE builds
 # Apps launched by expo run:* connect to Metro immediately on start.
@@ -472,15 +216,9 @@ _PIDS_TO_KILL+=("$_METRO_PID")
 
 # Wait for Metro to be ready
 log "Waiting for Metro to be ready..."
-local_retries=30
-while ! curl -sf --max-time 2 http://localhost:8081/status > /dev/null 2>&1; do
-  local_retries=$((local_retries - 1))
-  if [[ $local_retries -le 0 ]]; then
-    err "Metro did not start within 60 seconds."
-    exit 1
-  fi
-  sleep 2
-done
+if ! wait_for_url "http://localhost:8081/status" 30 2 "Metro bundler"; then
+  exit 1
+fi
 log "Metro bundler is ready."
 
 # Step 4: Platform-specific build

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# common.sh — Shared functions for run-dev.sh and run-e2e.sh
+#
+# Usage:
+#   source "$REPO_ROOT/scripts/lib/common.sh"
+#   init_log "[dev]"       # Set log prefix
+#   init_worktree          # Set up worktree deps if needed
+#
+# Callers MUST set these variables before sourcing:
+#   REPO_ROOT   — Absolute path to the repository root
+#   API_DIR     — Absolute path to apps/api
+#
+# This file exports:
+#   Functions: init_log, log, warn, err, info,
+#              init_worktree, kill_existing_metro, ensure_docker,
+#              ensure_backend, get_booted_ios_udid, get_android_emulator_id,
+#              setup_adb_reverse, boot_ios_simulator, boot_android_emulator,
+#              wait_for_url
+#   Variables: _MAIN_REPO_ROOT, _COMPOSE_PROJECT, API_PORT, API_HEALTH_URL
+
+# Guard: do nothing if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "This script is meant to be sourced, not executed directly." >&2
+  exit 1
+fi
+
+# ===========================================================================
+# Constants
+# ===========================================================================
+
+API_PORT=8000
+API_HEALTH_URL="http://localhost:${API_PORT}/health"
+
+# Initialized by init_worktree; callers may read these
+_MAIN_REPO_ROOT="$REPO_ROOT"
+_COMPOSE_PROJECT="$(basename "$REPO_ROOT")"
+
+# Colors
+_CLR_RED='\033[0;31m'
+_CLR_GREEN='\033[0;32m'
+_CLR_YELLOW='\033[0;33m'
+_CLR_CYAN='\033[0;36m'
+_CLR_NC='\033[0m'
+
+# ===========================================================================
+# Logging
+# ===========================================================================
+
+_LOG_PREFIX="[common]"
+
+init_log() {
+  _LOG_PREFIX="$1"
+}
+
+log()  { echo -e "${_CLR_GREEN}${_LOG_PREFIX}${_CLR_NC} $*"; }
+warn() { echo -e "${_CLR_YELLOW}${_LOG_PREFIX}${_CLR_NC} $*"; }
+err()  { echo -e "${_CLR_RED}${_LOG_PREFIX}${_CLR_NC} $*" >&2; }
+info() { echo -e "${_CLR_CYAN}${_LOG_PREFIX}${_CLR_NC} $*"; }
+
+# ===========================================================================
+# Worktree support
+# ===========================================================================
+
+init_worktree() {
+  source "$REPO_ROOT/scripts/setup-worktree.sh"
+  setup_worktree
+  _MAIN_REPO_ROOT="$WORKTREE_MAIN_REPO"
+  _COMPOSE_PROJECT="$WORKTREE_COMPOSE_PROJECT"
+}
+
+# ===========================================================================
+# Utility: wait for a URL to respond
+# ===========================================================================
+
+# wait_for_url URL MAX_RETRIES SLEEP_SECS LABEL
+# Returns 0 on success, 1 on timeout.
+wait_for_url() {
+  local url="$1" max_retries="$2" sleep_secs="$3" label="$4"
+  local retries="$max_retries"
+  while ! curl -sf --max-time 2 "$url" > /dev/null 2>&1; do
+    retries=$((retries - 1))
+    if [[ $retries -le 0 ]]; then
+      err "$label did not become ready within $(( max_retries * sleep_secs )) seconds."
+      return 1
+    fi
+    sleep "$sleep_secs"
+  done
+  return 0
+}
+
+# ===========================================================================
+# Metro
+# ===========================================================================
+
+# Kill any existing Metro process on port 8081
+kill_existing_metro() {
+  local pids
+  pids=$(lsof -ti :8081 2>/dev/null || true)
+  if [[ -z "$pids" ]]; then
+    return
+  fi
+
+  warn "Killing existing Metro process on port 8081 (PIDs: $pids)"
+  # Stage 1: graceful SIGTERM
+  echo "$pids" | xargs kill 2>/dev/null || true
+  sleep 2
+
+  # Stage 2: SIGKILL anything that didn't exit
+  local remaining
+  remaining=$(lsof -ti :8081 2>/dev/null || true)
+  if [[ -n "$remaining" ]]; then
+    warn "Metro did not exit after SIGTERM; force-killing (PIDs: $remaining)"
+    echo "$remaining" | xargs kill -9 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+# ===========================================================================
+# Docker
+# ===========================================================================
+
+ensure_docker() {
+  if docker info &>/dev/null; then
+    log "Docker daemon is running."
+  else
+    log "Starting Docker Desktop..."
+    open -a Docker 2>/dev/null || true
+    local retries=30
+    while ! docker info &>/dev/null; do
+      retries=$((retries - 1))
+      if [[ $retries -le 0 ]]; then
+        err "Docker did not start within 60 seconds."
+        return 1
+      fi
+      sleep 2
+    done
+    log "Docker Desktop started."
+  fi
+
+  if docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" ps --status running 2>/dev/null | grep -q "postgres"; then
+    log "Docker services already running."
+  else
+    log "Starting Docker services (Postgres + Redis)..."
+    docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" up -d
+    local retries=10
+    while ! docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" exec -T postgres pg_isready -U coyo -d coyo > /dev/null 2>&1; do
+      retries=$((retries - 1))
+      if [[ $retries -le 0 ]]; then
+        err "Postgres did not become ready."
+        return 1
+      fi
+      sleep 2
+    done
+    log "Docker services are running."
+  fi
+}
+
+# ===========================================================================
+# Backend
+# ===========================================================================
+
+# ensure_backend — Start the backend API if not already running.
+# On success, sets _BACKEND_PID to the uvicorn PID (empty string if API was
+# already running). Callers should use this to manage cleanup.
+_BACKEND_PID=""
+
+ensure_backend() {
+  _BACKEND_PID=""
+
+  if curl -sf --max-time 3 "$API_HEALTH_URL" > /dev/null 2>&1; then
+    log "Backend API already running."
+    return 0
+  fi
+
+  ensure_docker || return 1
+
+  # Verify venv
+  if [[ ! -x "$API_DIR/.venv/bin/python" ]]; then
+    err "Python venv not found at $API_DIR/.venv"
+    err "Create it with: cd $API_DIR && python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'"
+    return 1
+  fi
+
+  local venv_python
+  venv_python=$("$API_DIR/.venv/bin/python" -c "import sys; print(sys.executable)" 2>/dev/null || true)
+  if [[ -z "$venv_python" ]]; then
+    err "Python venv is broken. Recreate with: cd $API_DIR && python3 -m venv .venv --clear && .venv/bin/pip install -e '.[dev]'"
+    return 1
+  fi
+
+  # Run migrations
+  # When running in a worktree, the .venv editable install points to the
+  # main repo's src/. Override PYTHONPATH so the worktree's src/ takes priority.
+  log "Running database migrations..."
+  (cd "$API_DIR" && PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/alembic upgrade head 2>&1 | tail -3)
+
+  # Start uvicorn in background
+  log "Starting backend API..."
+  (cd "$API_DIR" && PYTHONPATH="$API_DIR/src:${PYTHONPATH:-}" .venv/bin/uvicorn src.coyo.main:app --port "$API_PORT") &
+  _BACKEND_PID=$!
+
+  if ! wait_for_url "$API_HEALTH_URL" 15 2 "Backend API"; then
+    kill "$_BACKEND_PID" 2>/dev/null || true
+    _BACKEND_PID=""
+    return 1
+  fi
+
+  log "Backend API is running (PID: $_BACKEND_PID)."
+}
+
+# ===========================================================================
+# Device detection
+# ===========================================================================
+
+get_booted_ios_udid() {
+  xcrun simctl list devices booted -j 2>/dev/null \
+    | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data.get('devices', {}).items():
+    for d in devices:
+        if d.get('state') == 'Booted':
+            print(d['udid'])
+            sys.exit(0)
+sys.exit(1)
+" 2>/dev/null || true
+}
+
+get_android_emulator_id() {
+  adb devices 2>/dev/null | grep -E "emulator-[0-9]+\s+device" | awk '{print $1}' | head -1 || true
+}
+
+# ===========================================================================
+# iOS Simulator
+# ===========================================================================
+
+boot_ios_simulator() {
+  local udid
+  udid=$(get_booted_ios_udid)
+  if [[ -n "$udid" ]]; then
+    log "iOS Simulator already booted: $udid"
+    return
+  fi
+
+  # Pick the first available iPhone simulator (prefer Pro models)
+  local target_udid
+  target_udid=$(xcrun simctl list devices available -j 2>/dev/null \
+    | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in sorted(data.get('devices', {}).items(), reverse=True):
+    for d in devices:
+        if d.get('isAvailable') and 'iPhone' in d.get('name', '') and 'Pro' in d.get('name', ''):
+            print(d['udid'])
+            sys.exit(0)
+# Fallback: any iPhone
+for runtime, devices in sorted(data.get('devices', {}).items(), reverse=True):
+    for d in devices:
+        if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
+            print(d['udid'])
+            sys.exit(0)
+sys.exit(1)
+" 2>/dev/null) || true
+
+  if [[ -z "$target_udid" ]]; then
+    err "No iPhone simulator found. Create one in Xcode > Window > Devices and Simulators."
+    return 1
+  fi
+
+  log "Booting iOS Simulator ($target_udid)..."
+  xcrun simctl boot "$target_udid" 2>/dev/null || true
+  open -a Simulator 2>/dev/null || true
+  sleep 3
+  log "iOS Simulator booted."
+}
+
+# ===========================================================================
+# Android Emulator
+# ===========================================================================
+
+# boot_android_emulator — Start an Android emulator if none is running.
+# Sets _EMULATOR_PID for callers to manage cleanup.
+_EMULATOR_PID=""
+
+boot_android_emulator() {
+  _EMULATOR_PID=""
+
+  local device_id
+  device_id=$(get_android_emulator_id)
+  if [[ -n "$device_id" ]]; then
+    log "Android Emulator already running: $device_id"
+    return
+  fi
+
+  if ! command -v adb &>/dev/null; then
+    err "adb not found. Install Android SDK platform-tools."
+    return 1
+  fi
+
+  local avd_name
+  avd_name=$("$ANDROID_HOME/emulator/emulator" -list-avds 2>/dev/null | head -1)
+  if [[ -z "$avd_name" ]]; then
+    err "No Android AVD found. Create one in Android Studio > Virtual Device Manager."
+    return 1
+  fi
+
+  log "Starting Android Emulator ($avd_name)..."
+  "$ANDROID_HOME/emulator/emulator" -avd "$avd_name" -no-snapshot-load &>/dev/null &
+  _EMULATOR_PID=$!
+
+  log "Waiting for emulator to boot..."
+  local retries=60
+  while true; do
+    device_id=$(get_android_emulator_id)
+    if [[ -n "$device_id" ]]; then
+      local boot_status
+      boot_status=$(adb -s "$device_id" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
+      if [[ "$boot_status" == "1" ]]; then
+        break
+      fi
+    fi
+    retries=$((retries - 1))
+    if [[ $retries -le 0 ]]; then
+      err "Android Emulator did not boot within 120 seconds."
+      return 1
+    fi
+    sleep 2
+  done
+  log "Android Emulator booted: $device_id"
+}
+
+# ===========================================================================
+# adb reverse
+# ===========================================================================
+
+setup_adb_reverse() {
+  local device_id="$1"
+  adb -s "$device_id" reverse tcp:8081 tcp:8081 2>/dev/null || true
+  adb -s "$device_id" reverse tcp:${API_PORT} tcp:${API_PORT} 2>/dev/null || true
+  log "adb reverse set up (ports 8081, ${API_PORT})."
+}


### PR DESCRIPTION
## Summary

- Extracted duplicated infrastructure functions from `run-dev.sh` and `run-e2e.sh` into a new shared library `scripts/lib/common.sh`
- `run-dev.sh` (-51%): now focused solely on infrastructure startup, app build, and Metro management
- `run-e2e.sh` (-40%): stripped of all infrastructure/build/Metro responsibilities; validates environment with `require_environment()` and runs Maestro tests
- Removed `SKIP_BUILD` option (builds are `run-dev.sh`'s responsibility)
- Fixed dead `wait_for_url` call in `ensure_docker` and missing error check on `ensure_backend`
- Updated `CLAUDE.md` and `Makefile` to document the two-terminal workflow (dev + e2e)

## Test plan

- [x] `make dev-ios` starts full dev environment (Docker → backend → Metro → Simulator → build → app install)
- [x] `make e2e-ios FLOW=app-launch.yaml` passes all Maestro assertions with exit code 0
- [ ] `make dev-android` + `make e2e-android` works on Android
- [ ] Verify worktree setup works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)