### PR TITLE
refactor: use AuthProvider StrEnum for auth_provider

### DIFF
--- a/apps/api/src/coyo/dependencies.py
+++ b/apps/api/src/coyo/dependencies.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.db import get_session_factory
 from coyo.exceptions import AuthenticationError
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 from coyo.repositories.user import UserRepository
 from coyo.services.firebase import FirebaseTokenPayload, verify_firebase_token
 
@@ -24,25 +24,26 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-_ALLOWED_PROVIDERS = frozenset({"email", "google", "apple"})
-
-_PROVIDER_MAPPING: dict[str, str] = {
-    "password": "email",
-    "google.com": "google",
-    "apple.com": "apple",
+_PROVIDER_MAPPING: dict[str, AuthProvider] = {
+    "password": AuthProvider.EMAIL,
+    "google.com": AuthProvider.GOOGLE,
+    "apple.com": AuthProvider.APPLE,
 }
 
 
-def map_provider(sign_in_provider: str) -> str:
+def map_provider(sign_in_provider: str) -> AuthProvider:
     """Map Firebase sign_in_provider to our auth_provider value."""
-    provider = _PROVIDER_MAPPING.get(sign_in_provider, sign_in_provider)
-    if provider not in _ALLOWED_PROVIDERS:
+    mapped = _PROVIDER_MAPPING.get(sign_in_provider)
+    if mapped is not None:
+        return mapped
+    try:
+        return AuthProvider(sign_in_provider)
+    except ValueError:
         logger.warning(
             "unknown_auth_provider",
             extra={"sign_in_provider": sign_in_provider, "fallback": "email"},
         )
-        return "email"
-    return provider
+        return AuthProvider.EMAIL
 
 
 async def get_firebase_token(

--- a/apps/api/src/coyo/models/user.py
+++ b/apps/api/src/coyo/models/user.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -17,13 +18,21 @@ if TYPE_CHECKING:
     from coyo.models.conversation import Conversation
 
 
+class AuthProvider(StrEnum):
+    """Supported authentication providers."""
+
+    EMAIL = "email"
+    GOOGLE = "google"
+    APPLE = "apple"
+
+
 class User(BaseModel):
     """Represents a user identified by an external authentication provider UID."""
 
     __tablename__ = "users"
     __table_args__ = (
         sa.CheckConstraint(
-            "auth_provider IN ('email', 'google', 'apple')",
+            f"auth_provider IN ({', '.join(repr(p.value) for p in AuthProvider)})",
             name="ck_users_auth_provider_valid",
         ),
     )

--- a/apps/api/src/coyo/repositories/user.py
+++ b/apps/api/src/coyo/repositories/user.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 
 
 class UserRepository:
@@ -24,7 +24,7 @@ class UserRepository:
         auth_uid: str,
         email: str | None,
         display_name: str | None,
-        auth_provider: str,
+        auth_provider: AuthProvider,
     ) -> User:
         """Find a user by auth_uid, or create one if not found.
 

--- a/apps/api/src/coyo/schemas/auth.py
+++ b/apps/api/src/coyo/schemas/auth.py
@@ -1,5 +1,6 @@
 """Schemas for authentication endpoints."""
 
+from coyo.models.user import AuthProvider
 from coyo.schemas.base import CamelModel
 
 
@@ -9,4 +10,4 @@ class SessionResponse(CamelModel):
     user_id: str
     email: str | None
     display_name: str | None
-    auth_provider: str
+    auth_provider: AuthProvider

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -17,7 +17,7 @@ from coyo.models.base import Base
 from coyo.models.conversation import Conversation
 from coyo.models.correction import CorrectionItem, TurnCorrection
 from coyo.models.turn import Turn
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 
 # ---------------------------------------------------------------------------
 # Database fixtures
@@ -74,7 +74,7 @@ async def test_user(db_session: AsyncSession) -> User:
     user = User(
         auth_uid=TEST_AUTH_UID,
         email="test@example.com",
-        auth_provider="email",
+        auth_provider=AuthProvider.EMAIL,
     )
     db_session.add(user)
     await db_session.commit()

--- a/apps/api/tests/unit/test_dependencies.py
+++ b/apps/api/tests/unit/test_dependencies.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.dependencies import get_current_user, get_firebase_token, map_provider
 from coyo.exceptions import AuthenticationError
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 from coyo.services.firebase import FirebaseTokenPayload
 
 # ---------------------------------------------------------------------------
@@ -20,23 +20,23 @@ class TestMapProvider:
 
     @pytest.mark.unit
     def test_password_maps_to_email(self):
-        assert map_provider("password") == "email"
+        assert map_provider("password") is AuthProvider.EMAIL
 
     @pytest.mark.unit
     def test_google_com_maps_to_google(self):
-        assert map_provider("google.com") == "google"
+        assert map_provider("google.com") is AuthProvider.GOOGLE
 
     @pytest.mark.unit
     def test_apple_com_maps_to_apple(self):
-        assert map_provider("apple.com") == "apple"
+        assert map_provider("apple.com") is AuthProvider.APPLE
 
     @pytest.mark.unit
     def test_unknown_provider_falls_back_to_email(self):
-        assert map_provider("unknown") == "email"
+        assert map_provider("unknown") is AuthProvider.EMAIL
 
     @pytest.mark.unit
     def test_custom_provider_falls_back_to_email(self):
-        assert map_provider("github.com") == "email"
+        assert map_provider("github.com") is AuthProvider.EMAIL
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ class TestGetCurrentUser:
             auth_uid="fb-uid-1",
             email="user@test.com",
             display_name="Firebase User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
 
     @pytest.mark.unit
@@ -167,7 +167,7 @@ class TestGetCurrentUser:
             )
 
         call_kwargs = mock_repo_instance.find_or_create_by_auth_uid.call_args.kwargs
-        assert call_kwargs["auth_provider"] == "google"
+        assert call_kwargs["auth_provider"] is AuthProvider.GOOGLE
 
     @pytest.mark.unit
     async def test_apple_provider_is_mapped_correctly(self):
@@ -192,4 +192,4 @@ class TestGetCurrentUser:
             )
 
         call_kwargs = mock_repo_instance.find_or_create_by_auth_uid.call_args.kwargs
-        assert call_kwargs["auth_provider"] == "apple"
+        assert call_kwargs["auth_provider"] is AuthProvider.APPLE

--- a/apps/api/tests/unit/test_repositories.py
+++ b/apps/api/tests/unit/test_repositories.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.models.conversation import Conversation
 from coyo.models.turn import Turn
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 from coyo.repositories.conversation import ConversationRepository
 from coyo.repositories.history import HistoryRepository
 from coyo.repositories.turn import TurnRepository
@@ -219,7 +219,7 @@ class TestUserRepository:
             auth_uid="fb-new-uid",
             email="new@example.com",
             display_name="New User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         assert user.id is not None
         assert user.auth_uid == "fb-new-uid"
@@ -247,13 +247,13 @@ class TestUserRepository:
             auth_uid="fb-idempotent-uid",
             email="idem@example.com",
             display_name="Idempotent",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         user2 = await repo.find_or_create_by_auth_uid(
             auth_uid="fb-idempotent-uid",
             email="idem@example.com",
             display_name="Idempotent",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         assert user1.id == user2.id
 
@@ -343,7 +343,7 @@ class TestHistoryRepository:
         # Create a different user
         other_user = User(
             auth_uid="fb-other-user",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(other_user)
         await db_session.commit()
@@ -376,7 +376,7 @@ class TestHistoryRepository:
         """Verify that a different user cannot delete the conversation."""
         other_user = User(
             auth_uid="fb-other-user-2",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(other_user)
         await db_session.commit()

--- a/apps/api/tests/unit/test_user_repository.py
+++ b/apps/api/tests/unit/test_user_repository.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from coyo.models.user import User
+from coyo.models.user import AuthProvider, User
 from coyo.repositories.user import UserRepository
 
 
@@ -21,14 +21,14 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-new-uid",
             email="new@example.com",
             display_name="New User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
 
         assert user.id is not None
         assert user.auth_uid == "fb-new-uid"
         assert user.email == "new@example.com"
         assert user.display_name == "New User"
-        assert user.auth_provider == "email"
+        assert user.auth_provider == AuthProvider.EMAIL
 
     @pytest.mark.unit
     async def test_returns_existing_user_when_found(self, db_session: AsyncSession):
@@ -37,7 +37,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-existing-uid",
             email="existing@example.com",
             display_name="Existing User",
-            auth_provider="google",
+            auth_provider=AuthProvider.GOOGLE,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -50,7 +50,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-existing-uid",
             email="existing@example.com",
             display_name="Existing User",
-            auth_provider="google",
+            auth_provider=AuthProvider.GOOGLE,
         )
 
         assert user.id == existing.id
@@ -61,7 +61,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-email-change",
             email="old@example.com",
             display_name="User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -73,7 +73,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-email-change",
             email="new@example.com",
             display_name="User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
 
         assert user.id == existing.id
@@ -85,7 +85,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-name-change",
             email="user@example.com",
             display_name="Old Name",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -97,7 +97,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-name-change",
             email="user@example.com",
             display_name="New Name",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
 
         assert user.display_name == "New Name"
@@ -108,7 +108,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-provider-change",
             email="user@example.com",
             display_name="User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -120,10 +120,10 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-provider-change",
             email="user@example.com",
             display_name="User",
-            auth_provider="google",
+            auth_provider=AuthProvider.GOOGLE,
         )
 
-        assert user.auth_provider == "google"
+        assert user.auth_provider == AuthProvider.GOOGLE
 
     @pytest.mark.unit
     async def test_no_commit_when_nothing_changed(self, db_session: AsyncSession):
@@ -131,7 +131,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-no-change",
             email="same@example.com",
             display_name="Same Name",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -143,7 +143,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-no-change",
             email="same@example.com",
             display_name="Same Name",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
 
         assert user.id == existing.id
@@ -156,7 +156,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-no-email",
             email=None,
             display_name=None,
-            auth_provider="apple",
+            auth_provider=AuthProvider.APPLE,
         )
 
         assert user.auth_uid == "fb-uid-no-email"
@@ -170,7 +170,7 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-multi-update",
             email="old@example.com",
             display_name="Old Name",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -182,13 +182,13 @@ class TestFindOrCreateByAuthUid:
             auth_uid="fb-uid-multi-update",
             email="new@example.com",
             display_name="New Name",
-            auth_provider="google",
+            auth_provider=AuthProvider.GOOGLE,
         )
 
         assert user.id == existing.id
         assert user.email == "new@example.com"
         assert user.display_name == "New Name"
-        assert user.auth_provider == "google"
+        assert user.auth_provider == AuthProvider.GOOGLE
 
 
 class TestFindOrCreateRaceCondition:
@@ -204,7 +204,7 @@ class TestFindOrCreateRaceCondition:
             auth_uid="fb-race-uid",
             email="race@example.com",
             display_name="Race User",
-            auth_provider="email",
+            auth_provider=AuthProvider.EMAIL,
         )
         db_session.add(existing)
         await db_session.commit()
@@ -235,7 +235,7 @@ class TestFindOrCreateRaceCondition:
                 auth_uid="fb-race-uid",
                 email="race@example.com",
                 display_name="Race User",
-                auth_provider="email",
+                auth_provider=AuthProvider.EMAIL,
             )
 
         assert user.id == existing.id
@@ -269,5 +269,5 @@ class TestFindOrCreateRaceCondition:
                 auth_uid="fb-nonexistent-uid",
                 email="ghost@example.com",
                 display_name="Ghost",
-                auth_provider="email",
+                auth_provider=AuthProvider.EMAIL,
             )


### PR DESCRIPTION
## Summary
- Create `AuthProvider(StrEnum)` with `EMAIL`, `GOOGLE`, `APPLE` values in `models/user.py`
- Replace magic strings and `_ALLOWED_PROVIDERS` frozenset in `dependencies.py` with enum-based `map_provider`
- Update `UserRepository.find_or_create_by_auth_uid` parameter type from `str` to `AuthProvider`
- Update `SessionResponse` schema to use `AuthProvider` (improves OpenAPI spec with enum constraint)
- Derive `CheckConstraint` from enum values to keep them in sync

Closes #27

## Test plan
- [x] All 56 relevant unit tests pass with `is AuthProvider.*` identity checks
- [ ] Run `make generate-api-types` to regenerate TypeScript types (requires dev environment)
- [ ] Verify mobile TypeScript compilation after type regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)