### PR TITLE
feat: manage Firebase config files per environment via EAS Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,12 @@ apps/mobile/e2e/screenshots/
 # === Google Play service account key ===
 apps/mobile/google-play-service-account.json
 
-# === Firebase configuration (contains API keys, per-environment) ===
+# === Firebase configuration ===
+# Root-level files (legacy, no longer used)
 apps/mobile/GoogleService-Info.plist
 apps/mobile/google-services.json
+# Production configs are decoded from EAS Secrets at build time
+apps/mobile/firebase/production/
 
 # === Firebase Admin SDK service account key ===
 apps/api/firebase-service-account.json

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,6 +1,14 @@
 import 'dotenv/config';
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
+const FIREBASE_DIR_MAP: Record<string, string> = {
+  development: 'development',
+  staging: 'production',
+  production: 'production',
+};
+const appEnv = process.env.APP_ENV ?? 'development';
+const firebaseDir = `./firebase/${FIREBASE_DIR_MAP[appEnv] ?? 'development'}`;
+
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'Coyo',
@@ -13,7 +21,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ios: {
     bundleIdentifier: 'to.coyo.app',
     supportsTablet: false,
-    googleServicesFile: process.env.GOOGLE_SERVICES_PLIST ?? './GoogleService-Info.plist',
+    googleServicesFile: process.env.GOOGLE_SERVICES_PLIST ?? `${firebaseDir}/GoogleService-Info.plist`,
     infoPlist: {
       GIDClientID: process.env.GID_CLIENT_ID ?? '',
     },
@@ -27,7 +35,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       foregroundImage: './assets/icon.png',
       backgroundColor: '#4A90E2',
     },
-    googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? './google-services.json',
+    googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? `${firebaseDir}/google-services.json`,
   },
   plugins: [
     'expo-secure-store',

--- a/apps/mobile/eas-build-pre-install.sh
+++ b/apps/mobile/eas-build-pre-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# EAS Build pre-install hook
+# Decodes Base64-encoded Firebase config files from EAS Secrets
+# for preview and production builds.
+#
+# Required EAS Secrets (Base64-encoded):
+#   GOOGLE_SERVICES_JSON_BASE64  — google-services.json for Android
+#   GOOGLE_SERVICES_PLIST_BASE64 — GoogleService-Info.plist for iOS
+
+set -euo pipefail
+
+FIREBASE_DIR="./firebase/production"
+
+if [ -n "${GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
+  echo "Decoding google-services.json from EAS Secret..."
+  mkdir -p "$FIREBASE_DIR"
+  echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > "$FIREBASE_DIR/google-services.json"
+  chmod 600 "$FIREBASE_DIR/google-services.json"
+  if ! python3 -c "import json; json.load(open('$FIREBASE_DIR/google-services.json'))" 2>/dev/null; then
+    echo "ERROR: google-services.json is not valid JSON" >&2
+    exit 1
+  fi
+  echo "Written and validated $FIREBASE_DIR/google-services.json"
+fi
+
+if [ -n "${GOOGLE_SERVICES_PLIST_BASE64:-}" ]; then
+  echo "Decoding GoogleService-Info.plist from EAS Secret..."
+  mkdir -p "$FIREBASE_DIR"
+  echo "$GOOGLE_SERVICES_PLIST_BASE64" | base64 --decode > "$FIREBASE_DIR/GoogleService-Info.plist"
+  chmod 600 "$FIREBASE_DIR/GoogleService-Info.plist"
+  if command -v plutil &>/dev/null; then
+    if ! plutil -lint "$FIREBASE_DIR/GoogleService-Info.plist" 2>/dev/null; then
+      echo "ERROR: GoogleService-Info.plist is not valid plist" >&2
+      exit 1
+    fi
+  fi
+  echo "Written and validated $FIREBASE_DIR/GoogleService-Info.plist"
+fi

--- a/apps/mobile/firebase/development/GoogleService-Info.plist
+++ b/apps/mobile/firebase/development/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>595448026395-d1vtu4cn06h2g3le497gtpp0n5vgu5l7.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.595448026395-d1vtu4cn06h2g3le497gtpp0n5vgu5l7</string>
+	<key>API_KEY</key>
+	<string>AIzaSyBNf4yQ5yqd8C9NDuLL0r36j2LCQab7Cfc</string>
+	<key>GCM_SENDER_ID</key>
+	<string>595448026395</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>to.coyo.app</string>
+	<key>PROJECT_ID</key>
+	<string>coyo-app-dev</string>
+	<key>STORAGE_BUCKET</key>
+	<string>coyo-app-dev.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:595448026395:ios:7583c068f379873aff6fbe</string>
+</dict>
+</plist>

--- a/apps/mobile/firebase/development/google-services.json
+++ b/apps/mobile/firebase/development/google-services.json
@@ -1,0 +1,54 @@
+{
+  "project_info": {
+    "project_number": "595448026395",
+    "project_id": "coyo-app-dev",
+    "storage_bucket": "coyo-app-dev.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:595448026395:android:46c8c9dfbe181e83ff6fbe",
+        "android_client_info": {
+          "package_name": "to.coyo.app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "595448026395-h9f7dhe761u93u1v6l8indqgipmn1ikf.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "to.coyo.app",
+            "certificate_hash": "5e8f16062ea3cd2c4a0d547876baa6f38cabf625"
+          }
+        },
+        {
+          "client_id": "595448026395-0npbpvm0ni23dileapq0nbqq7m75np2p.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDJQqn9ogVFq5CIwzyz2FzCoC-N2DnI03k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "595448026395-0npbpvm0ni23dileapq0nbqq7m75np2p.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "595448026395-d1vtu4cn06h2g3le497gtpp0n5vgu5l7.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "to.coyo.app"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary

- Organize Firebase config into `firebase/development/` and `firebase/production/` directories for environment isolation
- Development configs committed to repo (public identifiers only, safe to track)
- Production configs decoded from Base64 EAS Secrets at build time via `eas-build-pre-install.sh` with validation and `chmod 600`
- `app.config.ts` selects the correct Firebase directory based on `APP_ENV`

## Changed Files

| File | Change |
|---|---|
| `apps/mobile/firebase/development/` | Development Firebase configs (Android + iOS) |
| `apps/mobile/eas-build-pre-install.sh` | EAS Build pre-install hook: decode Base64 secrets, validate JSON/plist, restrict permissions |
| `apps/mobile/app.config.ts` | Environment-based Firebase config path resolution via `FIREBASE_DIR_MAP` |
| `.gitignore` | Production Firebase directory gitignored; development configs tracked |

## EAS Secrets Required (for preview/production builds)

| Secret Name | Description |
|---|---|
| `GOOGLE_SERVICES_JSON_BASE64` | Base64-encoded `google-services.json` (production Firebase project) |
| `GOOGLE_SERVICES_PLIST_BASE64` | Base64-encoded `GoogleService-Info.plist` (production Firebase project) |

## Test plan

- [x] TypeScript builds (`npx tsc --noEmit`)
- [x] E2E tests pass on iOS (6/8 passed; 2 failures are pre-existing issues tracked in #37, #38)
- [x] E2E test pass on Android (`app-launch` flow)
- [x] Production Firebase directory is gitignored (`git check-ignore` verified)
- [ ] Verify Firebase API key restrictions in Google Cloud Console (external, not a code change)
- [ ] Set EAS Secrets (`GOOGLE_SERVICES_JSON_BASE64`, `GOOGLE_SERVICES_PLIST_BASE64`) before first preview/production build

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)