### PR TITLE
chore: regenerate mobile TypeScript types for AuthProvider enum

### DIFF
--- a/apps/mobile/src/types/generated/api.ts
+++ b/apps/mobile/src/types/generated/api.ts
@@ -247,6 +247,12 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
+         * AuthProvider
+         * @description Supported authentication providers.
+         * @enum {string}
+         */
+        AuthProvider: "email" | "google" | "apple";
+        /**
          * BatchDeleteRequest
          * @description Request body for batch-deleting conversations.
          */
@@ -424,8 +430,7 @@ export interface components {
             email: string | null;
             /** Displayname */
             displayName: string | null;
-            /** Authprovider */
-            authProvider: string;
+            authProvider: components["schemas"]["AuthProvider"];
         };
         /**
          * TurnCorrectionResponse


### PR DESCRIPTION
## Summary
- Regenerate `apps/mobile/src/types/generated/api.ts` after #39 introduced `AuthProvider(StrEnum)`
- `authProvider` field type: `string` → `"email" | "google" | "apple"` (union literal)
- TypeScript compilation verified with `npx tsc --noEmit`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] No mobile code references `authProvider` outside the generated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)