### PR TITLE
fix: use clearState in auth-sign-in E2E to avoid parallel execution failure

### DIFF
--- a/apps/api/scripts/create_e2e_user.py
+++ b/apps/api/scripts/create_e2e_user.py
@@ -7,7 +7,7 @@ Usage:
 
 Requires:
     - FIREBASE_PROJECT_ID environment variable or .env file
-    - Application Default Credentials (gcloud auth application-default login)
+    - FIREBASE_SERVICE_ACCOUNT_PATH (preferred) or Application Default Credentials
 
 The script creates a user with email_verified=True so E2E tests
 can sign in without going through the email verification flow.
@@ -41,8 +41,18 @@ def main() -> None:
         print("ERROR: FIREBASE_PROJECT_ID environment variable is not set.")
         sys.exit(1)
 
-    # Initialize Firebase Admin SDK with ADC
-    cred = credentials.ApplicationDefault()
+    # Initialize Firebase Admin SDK
+    # Prefer service account key file; fall back to ADC (Cloud Run, etc.)
+    service_account_path = os.environ.get("FIREBASE_SERVICE_ACCOUNT_PATH")
+    api_dir = os.path.join(os.path.dirname(__file__), "..")
+
+    if service_account_path:
+        if not os.path.isabs(service_account_path):
+            service_account_path = os.path.join(api_dir, service_account_path)
+        cred = credentials.Certificate(service_account_path)
+    else:
+        cred = credentials.ApplicationDefault()
+
     firebase_admin.initialize_app(cred, {"projectId": project_id})
 
     # Check if user already exists

--- a/apps/mobile/e2e/auth-sign-in.yaml
+++ b/apps/mobile/e2e/auth-sign-in.yaml
@@ -1,9 +1,9 @@
 # auth-sign-in.yaml
 # Verifies the email/password sign-in flow: Welcome → Auth Modal → Sign In Form → Home.
 #
-# Uses clearState: true to wipe Keychain and app data before launch,
-# ensuring the app always starts from the Welcome screen regardless of
-# parallel test execution order.
+# This flow handles both states:
+#   - Already signed in → signs out first to reach the Welcome screen
+#   - Not signed in → proceeds directly to Welcome screen
 #
 # Prerequisites:
 # - E2E test user must exist in Firebase with email_verified=True
@@ -11,11 +11,19 @@
 # - Backend API must be running (run-e2e.sh starts it automatically)
 appId: to.coyo.app
 ---
-# Launch with clearState to ensure unauthenticated state (wipes Keychain)
+# Launch the application (clearState: false to preserve expo-dev-client settings)
 - launchApp:
-    clearState: true
+    clearState: false
 
-# Wait for the Welcome screen (auth gate — user is not signed in yet)
+# If already signed in (Home screen visible), sign out first.
+# This handles the case where parallel test execution signed in before us.
+- runFlow:
+    when:
+      visible:
+        id: "sign-out-button"
+    file: helpers/sign-out.yaml
+
+# Wait for the Welcome screen (auth gate — user is not signed in)
 - extendedWaitUntil:
     visible:
       id: "welcome-get-started"

--- a/apps/mobile/e2e/helpers/sign-out.yaml
+++ b/apps/mobile/e2e/helpers/sign-out.yaml
@@ -1,0 +1,19 @@
+# sign-out.yaml
+# Helper flow: signs out the current user from the Home screen.
+#
+# Prerequisites:
+# - The app must be on the Home screen (authenticated)
+# - The sign-out button (testID: sign-out-button) must be visible
+#
+# This file is NOT listed in config.yaml and is NOT a test flow.
+appId: to.coyo.app
+---
+# Tap the sign-out button on the Home screen
+- tapOn:
+    id: "sign-out-button"
+
+# Wait for the Welcome screen to appear after sign-out
+- extendedWaitUntil:
+    visible:
+      id: "welcome-get-started"
+    timeout: 15000


### PR DESCRIPTION
## Summary
- Fix `auth-sign-in.yaml` to conditionally sign out when a session persists from parallel test execution, then proceed with the sign-in flow
- `clearState: true` was not viable because it also wipes Expo Dev Client settings; use conditional sign-out (`runFlow` with `when`) instead
- Add `helpers/sign-out.yaml` as a reusable sign-out sub-flow
- Fix `create_e2e_user.py` to prefer `FIREBASE_SERVICE_ACCOUNT_PATH` over gcloud ADC

Closes #37

## Test plan
- [x] Run `make e2e-ios` full suite and confirm `auth-sign-in` passes
- [x] Confirm other flows (`app-launch`, `home-topic-cards`, etc.) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)