### PR TITLE
refactor: regenerate mobile types for AuthProvider StrEnum

### DIFF
--- a/apps/mobile/src/types/generated/api.ts
+++ b/apps/mobile/src/types/generated/api.ts
@@ -247,6 +247,12 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
+         * AuthProvider
+         * @description Supported authentication providers.
+         * @enum {string}
+         */
+        AuthProvider: "email" | "google" | "apple";
+        /**
          * BatchDeleteRequest
          * @description Request body for batch-deleting conversations.
          */
@@ -424,8 +430,7 @@ export interface components {
             email: string | null;
             /** Displayname */
             displayName: string | null;
-            /** Authprovider */
-            authProvider: string;
+            authProvider: components["schemas"]["AuthProvider"];
         };
         /**
          * TurnCorrectionResponse


### PR DESCRIPTION
## Summary
- Regenerated mobile OpenAPI TypeScript types to reflect the backend `AuthProvider` change from `str` to `StrEnum`
- The `authProvider` field type is now narrowed from `string` to `"email" | "google" | "apple"`, improving type safety

## Changed files
- `apps/mobile/src/types/generated/api.ts` — auto-regenerated via `make generate-api-types`

## Test plan
- [x] `npx tsc --noEmit` build verified
- [x] Confirmed generated types match backend schema (`AuthProvider(StrEnum)`)
- [x] Confirmed no breaking impact on mobile code

🤖 Generated with [Claude Code](https://claude.com/claude-code)