### PR TITLE
fix: sanitize error messages to prevent information leakage

### DIFF
--- a/apps/api/src/coyo/exceptions.py
+++ b/apps/api/src/coyo/exceptions.py
@@ -6,11 +6,28 @@ by a single centralized exception handler in middleware.
 
 
 class CoyoError(Exception):
-    """Base exception for all Coyo application errors."""
+    """Base exception for all Coyo application errors.
 
-    def __init__(self, message: str, code: str, status_code: int = 500) -> None:
+    Attributes:
+        message: Internal message for server-side logging (may contain
+            sensitive details such as resource IDs or service names).
+        client_message: Sanitized message safe to return to API clients.
+            Defaults to ``message`` when not explicitly overridden.
+        code: Machine-readable error code (e.g. "NOT_FOUND").
+        status_code: HTTP status code for the error response.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str,
+        status_code: int = 500,
+        *,
+        client_message: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.message = message
+        self.client_message = client_message if client_message is not None else message
         self.code = code
         self.status_code = status_code
 
@@ -19,7 +36,12 @@ class NotFoundError(CoyoError):
     """Raised when a requested resource does not exist."""
 
     def __init__(self, resource: str, id: str) -> None:
-        super().__init__(f"{resource} not found: {id}", "NOT_FOUND", 404)
+        super().__init__(
+            f"{resource} not found: {id}",
+            "NOT_FOUND",
+            404,
+            client_message="The requested resource was not found",
+        )
 
 
 class ValidationError(CoyoError):
@@ -33,21 +55,36 @@ class ConversationStateError(CoyoError):
     """Raised when an operation is invalid for the current conversation state."""
 
     def __init__(self, message: str) -> None:
-        super().__init__(message, "INVALID_STATE", 409)
+        super().__init__(
+            message,
+            "INVALID_STATE",
+            409,
+            client_message="This operation is not allowed for the current conversation state",
+        )
 
 
 class AuthenticationError(CoyoError):
     """Raised when authentication fails."""
 
     def __init__(self, message: str = "Authentication required") -> None:
-        super().__init__(message, "AUTHENTICATION_ERROR", 401)
+        super().__init__(
+            message,
+            "AUTHENTICATION_ERROR",
+            401,
+            client_message="Authentication required",
+        )
 
 
 class ExternalServiceError(CoyoError):
     """Raised when an external service (LLM, TTS, GCS) fails."""
 
     def __init__(self, service: str, detail: str) -> None:
-        super().__init__(f"{service} error: {detail}", "EXTERNAL_ERROR", 502)
+        super().__init__(
+            f"{service} error: {detail}",
+            "EXTERNAL_ERROR",
+            502,
+            client_message="An external service error occurred",
+        )
 
 
 class STTRecognitionError(CoyoError):

--- a/apps/api/src/coyo/middleware.py
+++ b/apps/api/src/coyo/middleware.py
@@ -76,7 +76,7 @@ async def coyo_error_handler(request: Request, exc: CoyoError) -> JSONResponse:
         content={
             "error": {
                 "code": exc.code,
-                "message": exc.message,
+                "message": exc.client_message,
             }
         },
     )

--- a/apps/api/tests/unit/test_exceptions.py
+++ b/apps/api/tests/unit/test_exceptions.py
@@ -3,6 +3,7 @@
 import pytest
 
 from coyo.exceptions import (
+    AuthenticationError,
     ConversationStateError,
     CoyoError,
     ExternalServiceError,
@@ -38,6 +39,19 @@ class TestCoyoError:
         error = CoyoError("test", "TEST")
         assert isinstance(error, Exception)
 
+    @pytest.mark.unit
+    def test_coyo_error_client_message_defaults_to_message(self):
+        error = CoyoError("internal detail", "TEST")
+        assert error.client_message == "internal detail"
+
+    @pytest.mark.unit
+    def test_coyo_error_custom_client_message(self):
+        error = CoyoError(
+            "internal detail", "TEST", 500, client_message="safe message"
+        )
+        assert error.message == "internal detail"
+        assert error.client_message == "safe message"
+
 
 class TestNotFoundError:
     """Tests for the NotFoundError exception."""
@@ -48,6 +62,13 @@ class TestNotFoundError:
         assert error.message == "Conversation not found: abc-123"
         assert error.code == "NOT_FOUND"
         assert error.status_code == 404
+
+    @pytest.mark.unit
+    def test_not_found_error_client_message_is_generic(self):
+        error = NotFoundError("Conversation", "abc-123")
+        assert error.client_message == "The requested resource was not found"
+        assert "abc-123" not in error.client_message
+        assert "Conversation" not in error.client_message
 
     @pytest.mark.unit
     def test_not_found_error_inheritance(self):
@@ -69,6 +90,7 @@ class TestNotFoundError:
         id_str = str(uuid.uuid4())
         error = NotFoundError("Conversation", id_str)
         assert id_str in error.message
+        assert id_str not in error.client_message
 
 
 class TestValidationError:
@@ -92,6 +114,11 @@ class TestValidationError:
         assert error.message == ""
         assert error.code == "VALIDATION_ERROR"
 
+    @pytest.mark.unit
+    def test_validation_error_client_message_matches_message(self):
+        error = ValidationError("Invalid email format")
+        assert error.client_message == error.message
+
 
 class TestConversationStateError:
     """Tests for the ConversationStateError exception."""
@@ -108,6 +135,32 @@ class TestConversationStateError:
         error = ConversationStateError("test")
         assert isinstance(error, CoyoError)
 
+    @pytest.mark.unit
+    def test_conversation_state_error_client_message_is_generic(self):
+        error = ConversationStateError(
+            "Cannot end conversation in 'completed' status"
+        )
+        assert "completed" not in error.client_message
+        assert error.client_message == (
+            "This operation is not allowed for the current conversation state"
+        )
+
+
+class TestAuthenticationError:
+    """Tests for the AuthenticationError exception."""
+
+    @pytest.mark.unit
+    def test_authentication_error_default_client_message(self):
+        error = AuthenticationError()
+        assert error.client_message == "Authentication required"
+
+    @pytest.mark.unit
+    def test_authentication_error_hides_internal_detail(self):
+        error = AuthenticationError("Firebase token expired")
+        assert error.message == "Firebase token expired"
+        assert error.client_message == "Authentication required"
+        assert "Firebase" not in error.client_message
+
 
 class TestExternalServiceError:
     """Tests for the ExternalServiceError exception."""
@@ -120,6 +173,13 @@ class TestExternalServiceError:
         assert error.status_code == 502
 
     @pytest.mark.unit
+    def test_external_service_error_client_message_is_generic(self):
+        error = ExternalServiceError("STT", "Connection timeout")
+        assert error.client_message == "An external service error occurred"
+        assert "STT" not in error.client_message
+        assert "Connection timeout" not in error.client_message
+
+    @pytest.mark.unit
     def test_external_service_error_different_services(self):
         stt_error = ExternalServiceError("STT", "failed")
         tts_error = ExternalServiceError("TTS", "timeout")
@@ -127,6 +187,8 @@ class TestExternalServiceError:
         assert "STT" in stt_error.message
         assert "TTS" in tts_error.message
         assert "OpenAI" in llm_error.message
+        # All should have the same generic client message
+        assert stt_error.client_message == tts_error.client_message == llm_error.client_message
 
     @pytest.mark.unit
     def test_external_service_error_inheritance(self):

--- a/apps/api/tests/unit/test_middleware.py
+++ b/apps/api/tests/unit/test_middleware.py
@@ -1,0 +1,95 @@
+"""Unit tests for middleware error handlers — client message sanitization."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from coyo.exceptions import (
+    AuthenticationError,
+    ExternalServiceError,
+    NotFoundError,
+    ValidationError,
+)
+from coyo.middleware import setup_middleware
+
+
+def _create_app() -> FastAPI:
+    """Create a minimal FastAPI app with error handlers for testing."""
+    app = FastAPI()
+
+    @app.get("/not-found")
+    async def _raise_not_found() -> None:
+        raise NotFoundError("Conversation", "secret-uuid-123")
+
+    @app.get("/external-error")
+    async def _raise_external() -> None:
+        raise ExternalServiceError("OpenAI", "rate limit exceeded for org-abc")
+
+    @app.get("/validation-error")
+    async def _raise_validation() -> None:
+        raise ValidationError("Invalid email format")
+
+    @app.get("/auth-error")
+    async def _raise_auth() -> None:
+        raise AuthenticationError("Firebase token expired")
+
+    setup_middleware(app)
+    return app
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return _create_app()
+
+
+@pytest.fixture
+async def client(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestErrorResponseSanitization:
+    """Verify that error responses do not leak internal details."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_not_found_error_hides_resource_id(self, client: AsyncClient):
+        resp = await client.get("/not-found")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["error"]["code"] == "NOT_FOUND"
+        assert "secret-uuid-123" not in body["error"]["message"]
+        assert "Conversation" not in body["error"]["message"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_external_service_error_hides_service_details(
+        self, client: AsyncClient
+    ):
+        resp = await client.get("/external-error")
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["error"]["code"] == "EXTERNAL_ERROR"
+        assert "OpenAI" not in body["error"]["message"]
+        assert "rate limit" not in body["error"]["message"]
+        assert "org-abc" not in body["error"]["message"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_validation_error_preserves_message(self, client: AsyncClient):
+        resp = await client.get("/validation-error")
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["error"]["code"] == "VALIDATION_ERROR"
+        assert body["error"]["message"] == "Invalid email format"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_auth_error_hides_firebase_details(self, client: AsyncClient):
+        resp = await client.get("/auth-error")
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["error"]["code"] == "AUTHENTICATION_ERROR"
+        assert "Firebase" not in body["error"]["message"]
+        assert body["error"]["message"] == "Authentication required"


### PR DESCRIPTION
## Summary
- Add `client_message` attribute to `CoyoError` base class for separating internal log messages from client-facing responses
- `NotFoundError`, `ExternalServiceError`, `AuthenticationError`, and `ConversationStateError` now return generic messages to API clients while preserving detailed messages for server-side logging
- Middleware `coyo_error_handler` uses `client_message` for responses, logs full `message` internally

## Test plan
- [x] Unit tests verify `client_message` defaults to `message` when not overridden
- [x] Unit tests verify sanitized exceptions do not leak resource IDs, service names, or auth provider details
- [x] Integration tests verify middleware returns sanitized messages in HTTP responses
- [x] `ValidationError` intentionally passes through its message (user-facing validation feedback)
- [x] All 31 tests pass

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)