### PR TITLE
fix: add CSP headers to app-redirect endpoint

### DIFF
--- a/apps/api/src/coyo/routers/auth.py
+++ b/apps/api/src/coyo/routers/auth.py
@@ -38,7 +38,12 @@ async def app_redirect(request: Request) -> HTMLResponse:
     After Firebase verifies the email in the browser, it redirects here,
     which in turn opens the app via the ``coyo://`` URL scheme.
     """
-    return HTMLResponse(content=_APP_REDIRECT_HTML)
+    return HTMLResponse(
+        content=_APP_REDIRECT_HTML,
+        headers={
+            "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'",
+        },
+    )
 
 
 @router.post("/session", response_model=SessionResponse)

--- a/apps/api/tests/unit/test_auth_router.py
+++ b/apps/api/tests/unit/test_auth_router.py
@@ -48,6 +48,31 @@ async def auth_client(
     app.dependency_overrides.clear()
 
 
+class TestAppRedirect:
+    """Tests for GET /api/auth/app-redirect."""
+
+    @pytest.mark.unit
+    async def test_app_redirect_returns_html(
+        self,
+        auth_client: AsyncClient,
+    ):
+        response = await auth_client.get("/api/auth/app-redirect")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+    @pytest.mark.unit
+    async def test_app_redirect_has_csp_header(
+        self,
+        auth_client: AsyncClient,
+    ):
+        response = await auth_client.get("/api/auth/app-redirect")
+
+        assert response.status_code == 200
+        csp = response.headers["content-security-policy"]
+        assert csp == "default-src 'none'; style-src 'unsafe-inline'"
+
+
 class TestSessionEndpoint:
     """Tests for POST /api/auth/session."""
 


### PR DESCRIPTION
## Summary
- Add `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` header to the `/api/auth/app-redirect` HTML response
- Add unit tests for the app-redirect endpoint (HTML response + CSP header)

Closes #25

## Test plan
- [x] Unit test verifies CSP header is present with correct value
- [x] Unit test verifies endpoint returns HTML
- [x] All existing auth router tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)