### PR TITLE
fix: validate CORS origins in production to require HTTPS

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -45,8 +45,10 @@ FIREBASE_PROJECT_ID=<your-firebase-project-id>
 # FIREBASE_SERVICE_ACCOUNT_PATH=
 
 # CORS
-# Set to your mobile app's origin or Cloud Run URL if needed
-CORS_ALLOWED_ORIGINS=["https://coyo-api-xxxxx-an.a.run.app"]
+# Defaults to [] (empty) in production, blocking all browser cross-origin requests.
+# Mobile apps are unaffected since CORS is a browser-only mechanism.
+# Only set this if you have a web frontend (e.g., admin panel) — all origins must use HTTPS.
+# CORS_ALLOWED_ORIGINS=["https://admin.example.com"]
 
 # Rate limiting
 RATE_LIMIT_PER_MINUTE=30

--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -1,10 +1,13 @@
 """Application settings loaded from environment variables."""
 
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, Self
+from urllib.parse import urlparse
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from pydantic_settings import BaseSettings
+
+_DEV_CORS_ORIGINS: tuple[str, ...] = ("http://localhost:8081", "http://localhost:19006")
 
 
 class Settings(BaseSettings):
@@ -41,7 +44,7 @@ class Settings(BaseSettings):
     firebase_service_account_path: str | None = None
 
     # CORS
-    cors_allowed_origins: list[str] = ["http://localhost:8081", "http://localhost:19006"]
+    cors_allowed_origins: list[str] = []
 
     # Upload limits
     max_audio_size_bytes: int = 10 * 1024 * 1024  # 10 MB
@@ -50,6 +53,30 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 30
 
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    @model_validator(mode="after")
+    def validate_cors_origins(self) -> Self:
+        """Validate CORS origins based on environment.
+
+        - Development/staging: uses default localhost origins if none configured.
+        - Production: rejects non-HTTPS origins to prevent insecure access.
+        """
+        if self.environment != "production":
+            if not self.cors_allowed_origins:
+                self.cors_allowed_origins = list(_DEV_CORS_ORIGINS)
+            return self
+
+        invalid_origins = [
+            origin
+            for origin in self.cors_allowed_origins
+            if urlparse(origin).scheme != "https" or not urlparse(origin).netloc
+        ]
+        if invalid_origins:
+            raise ValueError(
+                "In production, all CORS origins must use HTTPS. "
+                f"Invalid origins: {invalid_origins}"
+            )
+        return self
 
 
 @lru_cache(maxsize=1)

--- a/apps/api/tests/unit/test_config.py
+++ b/apps/api/tests/unit/test_config.py
@@ -1,0 +1,163 @@
+"""Unit tests for CORS origin validation in Settings."""
+
+import pytest
+from pydantic import ValidationError
+
+from coyo.config import Settings, _DEV_CORS_ORIGINS
+
+# Required fields that Settings needs but are irrelevant to CORS validation.
+_REQUIRED_FIELDS = {
+    "database_url": "sqlite+aiosqlite:///",
+    "redis_url": "redis://localhost:6379",
+    "openai_api_key": "test-key",
+}
+
+
+def _make_settings(**overrides: object) -> Settings:
+    """Create a Settings instance with required fields pre-filled."""
+    kwargs = {**_REQUIRED_FIELDS, **overrides}
+    return Settings.model_validate(kwargs)
+
+
+class TestCorsValidationDevelopment:
+    """CORS origin validation for non-production environments."""
+
+    @pytest.mark.unit
+    def test_development_empty_origins_auto_fills_dev_defaults(self):
+        settings = _make_settings(environment="development", cors_allowed_origins=[])
+
+        assert settings.cors_allowed_origins == list(_DEV_CORS_ORIGINS)
+
+    @pytest.mark.unit
+    def test_development_no_origins_specified_auto_fills_dev_defaults(self):
+        settings = _make_settings(environment="development")
+
+        assert settings.cors_allowed_origins == list(_DEV_CORS_ORIGINS)
+
+    @pytest.mark.unit
+    def test_development_explicit_origins_kept_as_is(self):
+        custom = ["http://192.168.1.100:3000", "http://my-dev-server:8080"]
+        settings = _make_settings(environment="development", cors_allowed_origins=custom)
+
+        assert settings.cors_allowed_origins == custom
+
+    @pytest.mark.unit
+    def test_development_allows_http_origins(self):
+        origins = ["http://example.com"]
+        settings = _make_settings(environment="development", cors_allowed_origins=origins)
+
+        assert settings.cors_allowed_origins == origins
+
+    @pytest.mark.unit
+    def test_development_auto_fill_does_not_mutate_module_constant(self):
+        settings = _make_settings(environment="development", cors_allowed_origins=[])
+
+        # Mutating the settings list should not affect the module constant.
+        settings.cors_allowed_origins.append("http://extra:9999")
+        assert _DEV_CORS_ORIGINS == ("http://localhost:8081", "http://localhost:19006")
+
+
+class TestCorsValidationStaging:
+    """Staging environment should behave like development."""
+
+    @pytest.mark.unit
+    def test_staging_empty_origins_auto_fills_dev_defaults(self):
+        settings = _make_settings(environment="staging", cors_allowed_origins=[])
+
+        assert settings.cors_allowed_origins == list(_DEV_CORS_ORIGINS)
+
+    @pytest.mark.unit
+    def test_staging_explicit_origins_kept_as_is(self):
+        custom = ["http://staging.example.com"]
+        settings = _make_settings(environment="staging", cors_allowed_origins=custom)
+
+        assert settings.cors_allowed_origins == custom
+
+
+class TestCorsValidationProduction:
+    """CORS origin validation for production environment."""
+
+    @pytest.mark.unit
+    def test_production_empty_origins_allowed(self):
+        settings = _make_settings(environment="production", cors_allowed_origins=[])
+
+        assert settings.cors_allowed_origins == []
+
+    @pytest.mark.unit
+    def test_production_https_origins_allowed(self):
+        origins = ["https://app.example.com", "https://admin.example.com"]
+        settings = _make_settings(
+            environment="production", cors_allowed_origins=origins
+        )
+
+        assert settings.cors_allowed_origins == origins
+
+    @pytest.mark.unit
+    def test_production_single_https_origin_allowed(self):
+        origins = ["https://myapp.com"]
+        settings = _make_settings(
+            environment="production", cors_allowed_origins=origins
+        )
+
+        assert settings.cors_allowed_origins == origins
+
+    @pytest.mark.unit
+    def test_production_http_origin_rejected(self):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=["http://insecure.example.com"],
+            )
+
+    @pytest.mark.unit
+    def test_production_localhost_http_rejected(self):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=["http://localhost:8081"],
+            )
+
+    @pytest.mark.unit
+    def test_production_localhost_https_allowed(self):
+        origins = ["https://localhost:8081"]
+        settings = _make_settings(
+            environment="production", cors_allowed_origins=origins
+        )
+
+        assert settings.cors_allowed_origins == origins
+
+    @pytest.mark.unit
+    def test_production_mixed_https_and_http_rejected(self):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=[
+                    "https://good.example.com",
+                    "http://bad.example.com",
+                ],
+            )
+
+    @pytest.mark.unit
+    def test_production_error_message_lists_invalid_origins(self):
+        bad_origin = "http://insecure.example.com"
+        with pytest.raises(ValidationError, match=bad_origin):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=[bad_origin],
+            )
+
+    @pytest.mark.unit
+    def test_production_origin_without_scheme_rejected(self):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=["example.com"],
+            )
+
+    @pytest.mark.unit
+    def test_production_wildcard_origin_rejected(self):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            _make_settings(
+                environment="production",
+                cors_allowed_origins=["*"],
+            )


### PR DESCRIPTION
## Summary
- Default `cors_allowed_origins` in production is now `[]` (empty), blocking all browser cross-origin requests. Mobile apps are unaffected since CORS is browser-only.
- If CORS origins are explicitly configured in production, all must use HTTPS — non-HTTPS origins cause a startup validation error.
- In development/staging, the previous localhost defaults (`http://localhost:8081`, `http://localhost:19006`) are auto-filled when none are configured.

## Changes
- `apps/api/src/coyo/config.py` — Added `model_validator` with HTTPS enforcement for production and dev auto-fill
- `apps/api/tests/unit/test_config.py` — 17 unit tests covering all environments and edge cases
- `.env.production.example` — Updated CORS documentation

## Test plan
- [x] 17 new unit tests pass (development, staging, production scenarios)
- [x] All 324 existing tests pass (no regressions)
- [ ] Verify production deployment starts correctly with empty CORS origins
- [ ] Verify production deployment rejects HTTP origins at startup

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)