### PR TITLE
docs: enforce E2E tests before commit for behavioral changes

### DIFF
--- a/.claude/rules/common/git.md
+++ b/.claude/rules/common/git.md
@@ -95,6 +95,29 @@ Claude MUST complete ALL of the following BEFORE creating any commit:
 2. **Tests passing** — All tests run and pass (`pytest` / `npx jest`)
 3. **Build passing** — Build verification succeeds (`npx tsc --noEmit` / `npx expo export` / equivalent)
 4. **Coverage verified** — Test coverage ≥ 80% for new/changed code
+5. **E2E tests run** — If the change affects app behavior (see criteria below), E2E tests MUST be run and pass BEFORE committing. Do NOT skip this step or defer it to "after the PR".
+
+### E2E Test Required Criteria
+
+E2E tests are REQUIRED when the change meets ANY of the following:
+
+- Modifies UI components, screens, or navigation flows
+- Changes API endpoints, request/response schemas, or error handling
+- Alters authentication, authorization, or session logic
+- Modifies form validation, input handling, or user interactions
+- Changes business logic that affects user-visible behavior
+- Updates state management that impacts what users see or do
+- Modifies database schemas or queries that back user-facing features
+
+E2E tests are NOT required for:
+
+- Documentation-only changes
+- Code style / linting / formatting changes
+- Internal refactoring with no user-visible behavior change (unit tests are sufficient)
+- Build configuration or CI pipeline changes
+- Adding or updating dev dependencies
+
+When in doubt, run E2E tests. Skipping E2E tests for behavioral changes has caused regressions in the past.
 
 Claude MUST NEVER create a commit or PR without completing these steps. If the user explicitly requests to skip testing, Claude should warn about risks but comply.
 

--- a/.claude/rules/common/workflow.md
+++ b/.claude/rules/common/workflow.md
@@ -98,13 +98,14 @@ Design elements are executed sequentially. Skip elements not relevant to the fea
     - **database-reviewer**: schema, indexes, queries, RLS (DB changes)
     - **python-reviewer**: PEP 8, type hints, Pythonic idioms (Python projects)
 
-13. **E2E Tests** (critical user flows)
+13. **E2E Tests** (MUST for behavioral changes — see [git.md](git.md) "E2E Test Required Criteria")
     - Web: use **web-e2e-tester** (Playwright)
     - Mobile: use **mobile-e2e-tester** (Maestro)
+    - Claude MUST NOT proceed to Commit & Push until E2E tests pass
 
 ### Phase 5: Finalize
 
-14. **Commit & Push**
+14. **Commit & Push** (BLOCKED until steps 11–13 are complete)
 15. **Documentation** (significant changes only)
     - Use **doc-updater** to update codemaps and docs
 
@@ -122,12 +123,12 @@ Reproduce-First: confirm the bug before fixing.
 6. **Test Coverage** - Verify reproduction test is sufficient; add tests if needed
    - Unit tests for the fixed behavior
    - Integration tests if the bug spans multiple components
-   - E2E tests if the bug affects a user flow - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
+   - E2E tests if the fix affects a user flow (see [git.md](git.md) "E2E Test Required Criteria") - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
 7. **Review** (run in parallel where possible)
    - **code-reviewer**: quality, patterns, maintainability
    - **security-reviewer**: vulnerabilities, input validation, secrets (auth/payment/API code)
    - **python-reviewer**: PEP 8, type hints, Pythonic idioms (Python projects)
-8. **Commit & Push**
+8. **Commit & Push** (BLOCKED until steps 5–7 are complete, including E2E if required)
 
 ---
 
@@ -143,13 +144,13 @@ Safety-Net-First: ensure existing behavior is protected.
 6. **Test Coverage** - Verify safety tests still pass; add tests if coverage gaps remain
    - Unit tests to verify refactored code behaves identically
    - Integration tests for changed interfaces or boundaries
-   - E2E tests if user-facing behavior could be affected - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
+   - E2E tests if user-facing behavior could be affected (see [git.md](git.md) "E2E Test Required Criteria") - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
 7. **Review** (run in parallel where possible)
    - **code-reviewer**: quality, patterns, maintainability
    - **security-reviewer**: vulnerabilities, input validation, secrets (auth/payment/API code)
    - **python-reviewer**: PEP 8, type hints, Pythonic idioms (Python projects)
    - **build-error-resolver** if build breaks
-8. **Commit & Push**
+8. **Commit & Push** (BLOCKED until steps 4–7 are complete, including E2E if required)
 
 ---
 
@@ -167,12 +168,12 @@ Schema-First: design the schema before writing application code.
 5. **Test Coverage** - Verify existing tests pass; add tests for new or changed behavior
    - Unit tests for data access logic
    - Integration tests for migrations and DB operations
-   - E2E tests if schema changes affect user flows - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
+   - E2E tests if schema changes affect user flows (see [git.md](git.md) "E2E Test Required Criteria") - use **web-e2e-tester** (web) or **mobile-e2e-tester** (mobile)
 6. **Review** (run in parallel where possible)
    - **code-reviewer**: quality, patterns, maintainability
    - **security-reviewer**: RLS, access control, input validation
    - **python-reviewer**: PEP 8, type hints, Pythonic idioms (Python projects)
-7. **Commit & Push**
+7. **Commit & Push** (BLOCKED until steps 5–6 are complete, including E2E if required)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add **E2E test requirement** (item 5) to the pre-commit checklist in `git.md` with explicit criteria for when E2E tests are required vs not required
- Add **BLOCKED gates** to all workflow commit steps (Feature, Bugfix, Refactor, DB Change) to prevent proceeding to commit before E2E tests pass
- Add cross-references from `workflow.md` E2E steps to the centralized criteria in `git.md`

## Test plan
- [ ] Verify Claude Code follows the new E2E requirement when making behavioral changes
- [ ] Verify Claude Code skips E2E for documentation-only or config-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)