### PR TITLE
fix: fail loudly on Firebase initialization failure in production

### DIFF
--- a/apps/api/src/coyo/main.py
+++ b/apps/api/src/coyo/main.py
@@ -23,7 +23,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         initialize_firebase(
             settings.firebase_project_id,
             service_account_path=settings.firebase_service_account_path,
+            fail_on_error=_is_prod,
         )
+    elif _is_prod:
+        raise RuntimeError("FIREBASE_PROJECT_ID must be set in production")
     yield
 
 

--- a/apps/api/src/coyo/services/firebase.py
+++ b/apps/api/src/coyo/services/firebase.py
@@ -31,12 +31,20 @@ class FirebaseTokenPayload:
 def initialize_firebase(
     project_id: str | None = None,
     service_account_path: str | None = None,
+    *,
+    fail_on_error: bool = False,
 ) -> None:
     """Initialize Firebase Admin SDK.
 
     Credential resolution order:
     1. Explicit service account key file (``service_account_path``)
     2. Application Default Credentials (ADC) — automatic on Cloud Run
+
+    Args:
+        project_id: Firebase project ID.
+        service_account_path: Path to service account JSON key file.
+        fail_on_error: If True, raise ``RuntimeError`` on initialization
+            failure instead of logging a warning and continuing.
     """
     global _firebase_app  # noqa: PLW0603
     if _firebase_app is not None:
@@ -54,6 +62,9 @@ def initialize_firebase(
         _firebase_app = firebase_initialize_app(cred, options)
         logger.info("firebase_initialized", project_id=project_id)
     except Exception as err:
+        if fail_on_error:
+            logger.error("firebase_init_failed", reason=str(err), error_type=type(err).__name__)
+            raise RuntimeError("Firebase initialization failed") from err
         logger.warning("firebase_init_skipped", reason=str(err), error_type=type(err).__name__)
 
 

--- a/apps/api/tests/unit/test_firebase_service.py
+++ b/apps/api/tests/unit/test_firebase_service.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from coyo.exceptions import AuthenticationError
-from coyo.services.firebase import FirebaseTokenPayload, verify_firebase_token
+from coyo.services.firebase import (
+    FirebaseTokenPayload,
+    initialize_firebase,
+    verify_firebase_token,
+)
 
 
 def _make_decoded_token(
@@ -25,6 +29,76 @@ def _make_decoded_token(
             "sign_in_provider": sign_in_provider,
         },
     }
+
+
+class TestInitializeFirebase:
+    """Tests for initialize_firebase()."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_firebase_app(self):
+        """Reset the global _firebase_app before each test."""
+        with patch("coyo.services.firebase._firebase_app", new=None):
+            yield
+
+    @pytest.mark.unit
+    @patch("coyo.services.firebase.firebase_initialize_app")
+    @patch("coyo.services.firebase.credentials.ApplicationDefault")
+    def test_successful_initialization(
+        self, mock_adc: MagicMock, mock_init: MagicMock
+    ):
+        mock_init.return_value = MagicMock()
+
+        initialize_firebase(project_id="test-project")
+
+        mock_adc.assert_called_once()
+        mock_init.assert_called_once()
+
+    @pytest.mark.unit
+    @patch("coyo.services.firebase.logger")
+    @patch("coyo.services.firebase.credentials.ApplicationDefault")
+    def test_fail_on_error_false_logs_warning_on_failure(
+        self, mock_adc: MagicMock, mock_logger: MagicMock
+    ):
+        mock_adc.side_effect = ValueError("no credentials")
+
+        # Should NOT raise
+        initialize_firebase(project_id="test-project", fail_on_error=False)
+
+        mock_logger.warning.assert_called_once()
+
+    @pytest.mark.unit
+    @patch("coyo.services.firebase.logger")
+    @patch("coyo.services.firebase.credentials.ApplicationDefault")
+    def test_fail_on_error_true_raises_runtime_error(
+        self, mock_adc: MagicMock, mock_logger: MagicMock
+    ):
+        mock_adc.side_effect = ValueError("no credentials")
+
+        with pytest.raises(RuntimeError, match="Firebase initialization failed"):
+            initialize_firebase(project_id="test-project", fail_on_error=True)
+
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.unit
+    @patch("coyo.services.firebase.credentials.ApplicationDefault")
+    def test_fail_on_error_true_chains_original_exception(
+        self, mock_adc: MagicMock
+    ):
+        original = ValueError("no credentials")
+        mock_adc.side_effect = original
+
+        with pytest.raises(RuntimeError) as exc_info:
+            initialize_firebase(project_id="test-project", fail_on_error=True)
+
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.unit
+    @patch("coyo.services.firebase.credentials.ApplicationDefault")
+    def test_default_fail_on_error_is_false(self, mock_adc: MagicMock):
+        mock_adc.side_effect = ValueError("no credentials")
+
+        # Default behavior: should NOT raise
+        initialize_firebase(project_id="test-project")
 
 
 class TestVerifyFirebaseToken:

--- a/apps/api/tests/unit/test_main.py
+++ b/apps/api/tests/unit/test_main.py
@@ -1,0 +1,63 @@
+"""Unit tests for the FastAPI application lifespan."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestLifespanFirebaseGuard:
+    """Tests for Firebase initialization guards in the lifespan function."""
+
+    @pytest.mark.unit
+    async def test_production_without_firebase_project_id_raises(self):
+        """Production must have FIREBASE_PROJECT_ID set."""
+        mock_settings = MagicMock()
+        mock_settings.firebase_project_id = None
+
+        with (
+            patch("coyo.main._is_prod", new=True),
+            patch("coyo.config.get_settings", return_value=mock_settings),
+            pytest.raises(RuntimeError, match="FIREBASE_PROJECT_ID must be set in production"),
+        ):
+            from coyo.main import app, lifespan
+
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.unit
+    async def test_non_production_without_firebase_project_id_succeeds(self):
+        """Non-production environments can run without FIREBASE_PROJECT_ID."""
+        mock_settings = MagicMock()
+        mock_settings.firebase_project_id = None
+
+        with (
+            patch("coyo.main._is_prod", new=False),
+            patch("coyo.config.get_settings", return_value=mock_settings),
+        ):
+            from coyo.main import app, lifespan
+
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.unit
+    async def test_production_with_firebase_project_id_calls_initialize(self):
+        """Production with FIREBASE_PROJECT_ID calls initialize_firebase."""
+        mock_settings = MagicMock()
+        mock_settings.firebase_project_id = "test-project"
+        mock_settings.firebase_service_account_path = "/path/to/sa.json"
+
+        with (
+            patch("coyo.main._is_prod", new=True),
+            patch("coyo.config.get_settings", return_value=mock_settings),
+            patch("coyo.services.firebase.initialize_firebase") as mock_init,
+        ):
+            from coyo.main import app, lifespan
+
+            async with lifespan(app):
+                pass
+
+            mock_init.assert_called_once_with(
+                "test-project",
+                service_account_path="/path/to/sa.json",
+                fail_on_error=True,
+            )


### PR DESCRIPTION
## Summary
- Raise `RuntimeError` when `FIREBASE_PROJECT_ID` is set but Firebase SDK initialization fails in production, preventing silently broken auth while `/health` returns ok
- Also raise `RuntimeError` when `FIREBASE_PROJECT_ID` is missing entirely in production (guards against misconfigured deployments)
- Log structured error details before raising to preserve debuggability without leaking internal paths in the exception message

## Changes
- `apps/api/src/coyo/services/firebase.py`: Added `fail_on_error` keyword-only parameter to `initialize_firebase()`
- `apps/api/src/coyo/main.py`: Pass `fail_on_error=_is_prod` and added missing project ID guard for production
- `apps/api/tests/unit/test_firebase_service.py`: 5 new tests for `initialize_firebase()` behavior
- `apps/api/tests/unit/test_main.py`: 3 new tests for lifespan Firebase guards

## Test plan
- [x] Unit tests for `fail_on_error=True` raises `RuntimeError`
- [x] Unit tests for `fail_on_error=False` logs warning (backward compatible)
- [x] Unit tests for exception chaining preserves original cause
- [x] Unit tests for missing `FIREBASE_PROJECT_ID` in production raises `RuntimeError`
- [x] Unit tests for non-production without `FIREBASE_PROJECT_ID` succeeds
- [x] Full test suite passes (324 tests)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)