### PR TITLE
test: add response body assertion to app-redirect test

### DIFF
--- a/apps/api/tests/unit/test_auth_router.py
+++ b/apps/api/tests/unit/test_auth_router.py
@@ -60,6 +60,7 @@ class TestAppRedirect:
 
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
+        assert "coyo://email-verified" in response.text
 
     @pytest.mark.unit
     async def test_app_redirect_has_csp_header(


### PR DESCRIPTION
## Summary
- Add `assert "coyo://email-verified" in response.text` to `test_app_redirect_returns_html` to verify the HTML body contains the expected custom URL scheme link
- Catches accidental changes to the redirect target

Closes #54

## Test plan
- [x] All 5 auth router tests pass
- [x] New assertion verifies redirect link presence in response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)