### PR TITLE
fix: add X-Content-Type-Options header to app-redirect endpoint

### DIFF
--- a/apps/api/src/coyo/routers/auth.py
+++ b/apps/api/src/coyo/routers/auth.py
@@ -42,6 +42,7 @@ async def app_redirect(request: Request) -> HTMLResponse:
         content=_APP_REDIRECT_HTML,
         headers={
             "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'",
+            "X-Content-Type-Options": "nosniff",
         },
     )
 

--- a/apps/api/tests/unit/test_auth_router.py
+++ b/apps/api/tests/unit/test_auth_router.py
@@ -72,6 +72,16 @@ class TestAppRedirect:
         csp = response.headers["content-security-policy"]
         assert csp == "default-src 'none'; style-src 'unsafe-inline'"
 
+    @pytest.mark.unit
+    async def test_app_redirect_has_x_content_type_options_header(
+        self,
+        auth_client: AsyncClient,
+    ):
+        response = await auth_client.get("/api/auth/app-redirect")
+
+        assert response.status_code == 200
+        assert response.headers["x-content-type-options"] == "nosniff"
+
 
 class TestSessionEndpoint:
     """Tests for POST /api/auth/session."""


### PR DESCRIPTION
## Summary
- Add `X-Content-Type-Options: nosniff` header to the `/api/auth/app-redirect` HTML response to prevent MIME-type sniffing
- Add unit test verifying the header is present

Closes #53

## Test plan
- [x] Unit test `test_app_redirect_has_x_content_type_options_header` added and passing
- [x] All existing auth router tests pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)