### PR TITLE
fix: validate Firebase config before prebuild and improve error messages

### DIFF
--- a/apps/mobile/e2e/run-e2e.sh
+++ b/apps/mobile/e2e/run-e2e.sh
@@ -411,6 +411,11 @@ run_android() {
   device_id=$(get_android_emulator_id)
   log "Using Android Emulator: $device_id"
 
+  # Disable Android autofill to prevent Google Password Manager dialogs
+  # from blocking input fields during E2E tests
+  log "Disabling Android autofill service..."
+  adb -s "$device_id" shell settings put secure autofill_service null 2>/dev/null || true
+
   # Ensure adb reverse is set up
   setup_adb_reverse "$device_id"
 

--- a/apps/mobile/run-dev.sh
+++ b/apps/mobile/run-dev.sh
@@ -196,16 +196,59 @@ info "  Coyo Development Environment"
 info "====================================="
 echo ""
 
-# Step 1: Kill leftover Metro to avoid port conflicts during build
+# Step 1: Validate Firebase config files before prebuild
+FIREBASE_DIR="$MOBILE_DIR/firebase/development"
+IOS_PLIST="$FIREBASE_DIR/GoogleService-Info.plist"
+ANDROID_JSON="$FIREBASE_DIR/google-services.json"
+
+if [[ ! -f "$IOS_PLIST" ]] || [[ ! -f "$ANDROID_JSON" ]]; then
+  # Auto-copy fallback: if config files exist at the mobile root (legacy location),
+  # copy them into firebase/development/ so app.config.ts can find them.
+  LEGACY_PLIST="$MOBILE_DIR/GoogleService-Info.plist"
+  LEGACY_JSON="$MOBILE_DIR/google-services.json"
+
+  if [[ -f "$LEGACY_PLIST" ]] || [[ -f "$LEGACY_JSON" ]]; then
+    warn "Firebase config not found in firebase/development/."
+    warn "Copying from legacy location (apps/mobile/ root)..."
+    mkdir -p "$FIREBASE_DIR"
+    [[ -f "$LEGACY_PLIST" ]] && cp "$LEGACY_PLIST" "$IOS_PLIST"
+    [[ -f "$LEGACY_JSON" ]]  && cp "$LEGACY_JSON"  "$ANDROID_JSON"
+    log "Firebase config copied to firebase/development/."
+
+    # Verify both files are now present after the copy
+    if [[ ! -f "$IOS_PLIST" ]] || [[ ! -f "$ANDROID_JSON" ]]; then
+      err "Firebase config is still incomplete after legacy copy."
+      [[ ! -f "$IOS_PLIST" ]]   && err "  Missing: GoogleService-Info.plist (iOS)"
+      [[ ! -f "$ANDROID_JSON" ]] && err "  Missing: google-services.json (Android)"
+      err ""
+      err "Download the missing file(s) from the Firebase Console"
+      err "and place them in: apps/mobile/firebase/development/"
+      exit 1
+    fi
+  else
+    err "Firebase config files not found."
+    err "Expected: $IOS_PLIST"
+    err "Expected: $ANDROID_JSON"
+    err ""
+    err "Download them from the Firebase Console:"
+    err "  1. Go to Firebase Console > Project Settings > General"
+    err "  2. Download GoogleService-Info.plist (iOS) and google-services.json (Android)"
+    err "  3. Place them in: apps/mobile/firebase/development/"
+    exit 1
+  fi
+fi
+log "Firebase config validated."
+
+# Step 2: Kill leftover Metro to avoid port conflicts during build
 kill_existing_metro
 
-# Step 2: Backend infrastructure
+# Step 3: Backend infrastructure
 ensure_backend || exit 1
 if [[ -n "$_BACKEND_PID" ]]; then
   _PIDS_TO_KILL+=("$_BACKEND_PID")
 fi
 
-# Step 3: Start Metro in background BEFORE builds
+# Step 4: Start Metro in background BEFORE builds
 # Apps launched by expo run:* connect to Metro immediately on start.
 # Metro must be running first, otherwise the dev client shows an error screen.
 log "Starting Metro bundler..."
@@ -221,7 +264,7 @@ if ! wait_for_url "http://localhost:8081/status" 30 2 "Metro bundler"; then
 fi
 log "Metro bundler is ready."
 
-# Step 4: Platform-specific build
+# Step 5: Platform-specific build
 case "$TARGET" in
   ios)
     run_ios
@@ -247,7 +290,7 @@ log "  Metro bundler running (PID: $_METRO_PID)"
 log "  Press Ctrl+C to stop all services."
 log ""
 
-# Step 5: Wait on Metro (foreground)
+# Step 6: Wait on Metro (foreground)
 # NOTE: Do NOT use `exec` here — it replaces the shell process and prevents
 # the trap handler from firing, leaving backend API and emulator processes
 # running after Ctrl+C. Instead, wait on Metro so that when it exits

--- a/apps/mobile/scripts/fix-firebase-swift-header.sh
+++ b/apps/mobile/scripts/fix-firebase-swift-header.sh
@@ -26,6 +26,24 @@ if [ ! -d "$PODS_PROJECT" ]; then
   exit 1
 fi
 
+# Verify FirebaseAuth target exists in the Pods project.
+# If Firebase config files (GoogleService-Info.plist) were missing during
+# expo prebuild, the Firebase plugins are excluded and this target won't exist.
+if ! xcodebuild -project "$PODS_PROJECT" -list 2>/dev/null | grep -q "FirebaseAuth"; then
+  echo "[Firebase] Error: FirebaseAuth target not found in Pods project."
+  echo ""
+  echo "  This usually means Firebase config files were missing during 'expo prebuild'."
+  echo "  Verify that the following files exist:"
+  echo "    apps/mobile/firebase/development/GoogleService-Info.plist"
+  echo "    apps/mobile/firebase/development/google-services.json"
+  echo ""
+  echo "  To fix:"
+  echo "    1. Place the Firebase config files in apps/mobile/firebase/development/"
+  echo "    2. Delete the ios/ directory: rm -rf ios/"
+  echo "    3. Re-run: npx expo prebuild --platform ios --clean"
+  exit 1
+fi
+
 echo "[Firebase] Building FirebaseAuth target to generate -Swift.h ..."
 xcodebuild \
   -project "$PODS_PROJECT" \
@@ -39,6 +57,9 @@ SWIFT_H=$(find "$IOS_DIR/build" -name "FirebaseAuth-Swift.h" \
 
 if [ -z "$SWIFT_H" ] || [ ! -f "$SWIFT_H" ]; then
   echo "[Firebase] Error: FirebaseAuth-Swift.h was not generated."
+  echo ""
+  echo "  The FirebaseAuth target exists but the Swift header build failed."
+  echo "  Check xcodebuild output for details."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add Firebase config validation in `run-dev.sh` before `expo prebuild` with auto-copy fallback from legacy location (`apps/mobile/` root → `firebase/development/`)
- Disable Android autofill in `run-e2e.sh` to prevent Google Password Manager dialogs from blocking E2E test input fields
- Add `FirebaseAuth` target existence check in `fix-firebase-swift-header.sh` with actionable error message pointing to missing config files

Closes #64

## Test plan

- [x] Run `make dev-ios` with Firebase config files only at `apps/mobile/` root (legacy) — should auto-copy and succeed
- [x] Run `make dev-ios` — full build including expo prebuild, FirebaseAuth-Swift.h generation, xcodebuild, app install, Metro bundle, API communication all passed
- [x] Run `make dev-android` with Firebase config files only at `apps/mobile/` root (legacy) — should auto-copy and succeed
- [x] Run `make dev-android` — full build including expo run:android, app install, Metro bundle, API communication all passed
- [ ] Run `make dev-ios` with no Firebase config files anywhere — should fail early with clear error message (cannot test in worktree; `setup-worktree.sh` auto-copies from main repo)
- [ ] Run `make e2e-android` — should disable autofill before tests, no Password Manager dialog
- [ ] Delete `ios/` and run `npx expo prebuild --platform ios` without Firebase config, then run `fix-firebase-swift-header.sh` — should show actionable error about missing config

🤖 Generated with [Claude Code](https://claude.com/claude-code)