### PR TITLE
docs: clarify testing requirements for shell scripts and tooling changes

### DIFF
--- a/.claude/rules/common/git.md
+++ b/.claude/rules/common/git.md
@@ -93,6 +93,7 @@ Claude MUST complete ALL of the following BEFORE creating any commit:
 
 1. **Tests written** — Unit tests (and integration tests if API/DB changes) for all new/changed code
 2. **Tests passing** — All tests run and pass (`pytest` / `npx jest`)
+   > NOTE: "Tests passing" includes manual functional verification for code that lacks formal test frameworks (shell scripts, CI configs, etc.). `bash -n` or `shellcheck` alone is NOT sufficient — the script must be actually executed in realistic scenarios.
 3. **Build passing** — Build verification succeeds (`npx tsc --noEmit` / `npx expo export` / equivalent)
 4. **Coverage verified** — Test coverage ≥ 80% for new/changed code
 5. **E2E tests run** — If the change affects app behavior (see criteria below), E2E tests MUST be run and pass BEFORE committing. Do NOT skip this step or defer it to "after the PR".

--- a/.claude/rules/common/testing.md
+++ b/.claude/rules/common/testing.md
@@ -18,6 +18,16 @@ Testing timing and approach vary by workflow type (see [workflow.md](workflow.md
 | **Refactor** | Before refactor (safety net) + after refactor (coverage check) | Safety tests first, then verify behavior preserved |
 | **DB Change** | After implementation | Focus on integration tests for migrations and queries |
 
+## Testing for Shell Scripts / Tooling
+
+When no formal test framework exists (shell scripts, Makefiles, CI configs),
+functional verification by execution IS the test:
+
+1. **Success path** — Run with valid inputs, verify expected output
+2. **Fallback path** — Trigger fallback conditions, verify recovery
+3. **Error path** — Remove prerequisites, verify early failure with clear message
+4. **Document results** — Record what was tested and the outcome before committing
+
 ## Edge Cases (MUST Test)
 
 1. **Null/Undefined** - What if input is null or undefined?

--- a/.claude/rules/common/workflow.md
+++ b/.claude/rules/common/workflow.md
@@ -117,7 +117,11 @@ Reproduce-First: confirm the bug before fixing.
 
 1. **Investigate** - Use **explorer** agent to trace the bug's root cause
 2. **Create Branch**
-3. **Reproduce** - Write a failing test or confirm reproduction steps
+3. **Reproduce** - Confirm the bug exists before fixing
+   - Execute the failing scenario and capture the error output
+   - If a formal test can be written, write a failing test
+   - If not (shell scripts, config), document the reproduction steps and observed error
+   - Do NOT proceed to Fix without confirmed reproduction
 4. **Fix** - Implement minimal fix
 5. **Verify** - Confirm the reproduction test passes
 6. **Test Coverage** - Verify reproduction test is sufficient; add tests if needed


### PR DESCRIPTION
## Summary
- Add "Testing for Shell Scripts / Tooling" section to `common/testing.md` with explicit guidance for verifying code that lacks formal test frameworks (success, fallback, error paths + documenting results)
- Clarify "Tests passing" in `common/git.md` pre-commit checklist: `bash -n` / `shellcheck` alone is NOT sufficient — scripts must be executed in realistic scenarios
- Strengthen Bugfix Workflow Reproduce step in `common/workflow.md` with detailed sub-steps to prevent skipping reproduction

Closes #66

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm no broken links in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)