### PR TITLE
ci: improve deploy workflow with Python setup, migration check, and Firebase config

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       # Authenticate to GCP via Workload Identity Federation (no service account keys)
       - id: auth
         uses: google-github-actions/auth@v2
@@ -47,14 +51,30 @@ jobs:
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
       # Run database migrations
-      - name: Run migrations
+      - name: Check pending migrations
+        id: migration-check
         run: |
           pip install -e "apps/api"
-          cd apps/api && alembic upgrade head
+          cd apps/api
+          if alembic check 2>&1 | grep -q "No new upgrade operations detected"; then
+            echo "has_pending=false" >> $GITHUB_OUTPUT
+            echo "No pending migrations"
+          else
+            echo "has_pending=true" >> $GITHUB_OUTPUT
+            echo "Pending migrations detected"
+          fi
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          REDIS_URL: "redis://localhost:6379"
-          OPENAI_API_KEY: "sk-dummy-for-migrations"
+          REDIS_URL: "memory://"
+          OPENAI_API_KEY: "dummy"
+
+      - name: Run migrations
+        if: steps.migration-check.outputs.has_pending == 'true'
+        run: cd apps/api && alembic upgrade head
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REDIS_URL: "memory://"
+          OPENAI_API_KEY: "dummy"
 
       # Deploy to Cloud Run
       - name: Deploy to Cloud Run
@@ -79,6 +99,7 @@ jobs:
             GCS_BUCKET_NAME=${{ vars.GCS_BUCKET_NAME }}
             RATE_LIMIT_PER_MINUTE=30
             CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS || '[]' }}
+            FIREBASE_PROJECT_ID=${{ vars.FIREBASE_PROJECT_ID }}
           secrets: |
             DATABASE_URL=database-url:latest
             REDIS_URL=redis-url:latest


### PR DESCRIPTION
## Summary
- Pin Python 3.12 via `actions/setup-python@v5` to avoid depending on runner default
- Add `alembic check` step to detect pending migrations and skip `alembic upgrade head` when none exist
- Replace unreachable dummy `REDIS_URL` / `OPENAI_API_KEY` values with safer defaults (`memory://`, `dummy`)
- Add `FIREBASE_PROJECT_ID` to Cloud Run environment variables

## Test plan
- [x] Verify `FIREBASE_PROJECT_ID` is set in GitHub Variables
- [ ] Trigger workflow via `workflow_dispatch` and confirm migration check step works
- [ ] Confirm deployment succeeds with no pending migrations (skip behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)