### PR TITLE
docs: replace deprecated eas secret:create with eas env:create

### DIFF
--- a/docs/DEPLOY-FIREBASE-AUTH.md
+++ b/docs/DEPLOY-FIREBASE-AUTH.md
@@ -200,14 +200,26 @@ Production config files are stored as Base64-encoded EAS Secrets and decoded at 
 cd apps/mobile
 
 # Base64-encode and store GoogleService-Info.plist as EAS Secret
-base64 -i /path/to/production/GoogleService-Info.plist | eas secret:create \
-  --name GOOGLE_SERVICES_PLIST_BASE64 \
-  --scope project --force
+VALUE=$(base64 -i '/path/to/production/GoogleService-Info.plist')
+
+eas env:create --name GOOGLE_SERVICES_PLIST_BASE64 \
+  --value "$VALUE" \
+  --scope project \
+  --type string \
+  --visibility secret \
+  --environment production \
+  --force
 
 # Base64-encode and store google-services.json as EAS Secret
-base64 -i /path/to/production/google-services.json | eas secret:create \
-  --name GOOGLE_SERVICES_JSON_BASE64 \
-  --scope project --force
+VALUE=$(base64 -i '/path/to/production/google-services.json')
+
+eas env:create --name GOOGLE_SERVICES_JSON_BASE64 \
+  --value "$VALUE" \
+  --scope project \
+  --type string \
+  --visibility secret \
+  --environment production \
+  --force
 ```
 
 2. **Pre-install hook** (`eas-build-pre-install.sh`) runs automatically during EAS Build:
@@ -223,12 +235,22 @@ base64 -i /path/to/production/google-services.json | eas secret:create \
 cd apps/mobile
 
 # Google Web Client ID (required for Google Sign-In)
-eas secret:create --name GOOGLE_WEB_CLIENT_ID \
-  --value "<web-client-id>" --scope project
+eas env:create --name GOOGLE_WEB_CLIENT_ID \
+  --value "<web-client-id>" \
+  --scope project \
+  --type string \
+  --visibility secret \
+  --environment production \
+  --force
 
 # iOS Google Client ID (CLIENT_ID from GoogleService-Info.plist)
-eas secret:create --name GID_CLIENT_ID \
-  --value "<ios-client-id>" --scope project
+eas env:create --name GID_CLIENT_ID \
+  --value "<ios-client-id>" \
+  --scope project \
+  --type string \
+  --visibility secret \
+  --environment production \
+  --force
 ```
 
 ### C.3 Update eas.json


### PR DESCRIPTION
## Summary
- Replace deprecated `eas secret:create` with `eas env:create` in DEPLOY-FIREBASE-AUTH.md (sections C.1 and C.2)
- Add explicit `--type string`, `--visibility secret`, and `--environment production` flags
- Use variable assignment for base64 values instead of piping

## Test plan
- [x] Verify the updated `eas env:create` commands work correctly with EAS CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)