### PR TITLE
feat: add Firebase Auth env vars to EAS build profiles

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -18,7 +18,10 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "APP_ENV": "staging"
+        "APP_ENV": "production",
+        "API_BASE_URL": "https://coyo-api-1008709417218.asia-northeast1.run.app",
+        "GOOGLE_WEB_CLIENT_ID": "595448026395-0npbpvm0ni23dileapq0nbqq7m75np2p.apps.googleusercontent.com",
+        "GID_CLIENT_ID": "595448026395-d1vtu4cn06h2g3le497gtpp0n5vgu5l7.apps.googleusercontent.com"
       },
       "ios": {
         "enterpriseProvisioning": "adhoc"
@@ -27,7 +30,10 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "APP_ENV": "production"
+        "APP_ENV": "production",
+        "API_BASE_URL": "https://coyo-api-1008709417218.asia-northeast1.run.app",
+        "GOOGLE_WEB_CLIENT_ID": "595448026395-0npbpvm0ni23dileapq0nbqq7m75np2p.apps.googleusercontent.com",
+        "GID_CLIENT_ID": "595448026395-d1vtu4cn06h2g3le497gtpp0n5vgu5l7.apps.googleusercontent.com"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Add `API_BASE_URL`, `GOOGLE_WEB_CLIENT_ID`, and `GID_CLIENT_ID` to preview and production EAS build profiles
- Unify preview `APP_ENV` to `"production"` since both profiles target the production API

## Test plan
- [ ] Verify `eas build --profile preview --platform ios` picks up the new env vars
- [ ] Verify `eas build --profile production --platform ios` picks up the new env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)