### PR TITLE
fix: fall back to development Firebase config for local EAS CLI pre-check

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -14,13 +14,15 @@ const firebaseDir = `./firebase/${FIREBASE_DIR_MAP[appEnv] ?? 'development'}`;
 // On EAS Build, production Firebase configs are decoded by eas-build-pre-install.sh
 // before prebuild runs. However, EAS CLI also evaluates this config locally
 // (via `npx expo config`) before uploading the project, at which point
-// production files do not exist. Return undefined so the local pre-check
-// does not fail with ENOENT. The config plugin mods that actually require the
-// file only run during prebuild on the remote builder, where the file exists.
-function resolveFirebaseConfig(filename: string): string | undefined {
+// production files do not exist. Fall back to development configs for the
+// local pre-check only — the actual build on the remote builder will use the
+// correct production files decoded by the pre-install hook.
+const FALLBACK_DIR = './firebase/development';
+
+function resolveFirebaseConfig(filename: string): string {
   const primary = `${firebaseDir}/${filename}`;
   if (fs.existsSync(primary)) return primary;
-  return undefined;
+  return `${FALLBACK_DIR}/${filename}`;
 }
 
 export default ({ config }: ConfigContext): ExpoConfig => ({


### PR DESCRIPTION
## Summary

- Follow-up to #72: `undefined` for `googleServicesFile` caused `@react-native-firebase/auth` to throw an error
- Fall back to development Firebase configs when production files do not exist locally
- This only affects the local `npx expo config` evaluation by EAS CLI — the remote builder uses production files decoded by `eas-build-pre-install.sh`

## Test plan

- [ ] Run `eas build --platform ios --profile preview` and verify the build starts without errors
- [ ] Run `eas build --platform android --profile preview` and verify the build starts without errors
- [ ] Verify local development (`npx expo run:ios`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)