### PR TITLE
fix: decode Firebase config from EAS Secrets at config evaluation time

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import 'dotenv/config';
 import type { ExpoConfig, ConfigContext } from 'expo/config';
@@ -10,14 +11,32 @@ const FIREBASE_DIR_MAP: Record<string, string> = {
 };
 const appEnv = process.env.APP_ENV ?? 'development';
 const firebaseDir = `./firebase/${FIREBASE_DIR_MAP[appEnv] ?? 'development'}`;
-
-// On EAS Build, production Firebase configs are decoded by eas-build-pre-install.sh
-// before prebuild runs. However, EAS CLI also evaluates this config locally
-// (via `npx expo config`) before uploading the project, at which point
-// production files do not exist. Fall back to development configs for the
-// local pre-check only — the actual build on the remote builder will use the
-// correct production files decoded by the pre-install hook.
 const FALLBACK_DIR = './firebase/development';
+
+// On EAS Build, Firebase config files are not in the git repo (gitignored).
+// They are provided as Base64-encoded EAS Secrets. This function decodes them
+// to disk at config evaluation time — before resolveFirebaseConfig() runs —
+// so that googleServicesFile paths resolve correctly during both the local
+// pre-check (`npx expo config`) and the remote prebuild step.
+function decodeFirebaseSecretsIfNeeded(): void {
+  const secrets: Array<{ envVar: string; filename: string }> = [
+    { envVar: 'GOOGLE_SERVICES_JSON_BASE64', filename: 'google-services.json' },
+    { envVar: 'GOOGLE_SERVICES_PLIST_BASE64', filename: 'GoogleService-Info.plist' },
+  ];
+
+  for (const { envVar, filename } of secrets) {
+    const base64Value = process.env[envVar];
+    if (!base64Value) continue;
+
+    const targetPath = path.join(firebaseDir, filename);
+    if (fs.existsSync(targetPath)) continue;
+
+    fs.mkdirSync(firebaseDir, { recursive: true });
+    fs.writeFileSync(targetPath, Buffer.from(base64Value, 'base64'), { mode: 0o600 });
+  }
+}
+
+decodeFirebaseSecretsIfNeeded();
 
 function resolveFirebaseConfig(filename: string): string {
   const primary = `${firebaseDir}/${filename}`;


### PR DESCRIPTION
## Summary

- Move Firebase config Base64 decoding from `eas-build-pre-install.sh` (which was not being executed) into `app.config.ts` via `decodeFirebaseSecretsIfNeeded()`
- The function runs at config evaluation time, before `resolveFirebaseConfig()`, ensuring `GoogleService-Info.plist` and `google-services.json` exist when `@react-native-firebase` config plugins need them during prebuild
- Skips decoding if files already exist or if Base64 env vars are not set (safe no-op for local development)

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] `npx expo config` works correctly with development fallback
- [x] Functional test: Base64 secrets decoded to correct files with 600 permissions
- [x] Functional test: No-op when env vars are absent
- [x] Functional test: Existing files are not overwritten
- [ ] Run `npx eas build --platform ios --profile preview` to verify remote build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)