### PR TITLE
fix: exclude node_modules from tsconfig include scope

### DIFF
--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -6,5 +6,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Added `"exclude": ["node_modules"]` to `apps/mobile/tsconfig.json`
- When `include` is explicitly set, TypeScript no longer auto-excludes `node_modules`, causing IDE errors on third-party files (e.g. `@react-native-firebase/app/plugin/tsconfig.json`)

## Test plan
- [ ] Verify no TypeScript errors from `node_modules` in IDE
- [ ] Verify `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)