### PR TITLE
fix: install expo-build-properties dependency for static frameworks

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo": "~52.0.0",
         "expo-asset": "~11.0.5",
         "expo-av": "~15.0.2",
+        "expo-build-properties": "^55.0.9",
         "expo-constants": "~17.0.0",
         "expo-crypto": "~14.0.0",
         "expo-dev-client": "~5.0.20",
@@ -3049,6 +3050,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@expo/schema-utils": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.2.tgz",
+      "integrity": "sha512-QZ5WKbJOWkCrMq0/kfhV9ry8te/OaS34YgLVpG8u9y2gix96TlpRTbxM/YATjNcUR2s4fiQmPCOxkGtog4i37g==",
+      "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
       "version": "1.0.0",
@@ -8994,6 +9001,20 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.9.tgz",
+      "integrity": "sha512-p0rNHW/6ghKsvjlUn2DQfbLYuTB6ba+15SeTPOz5BYbyU1F/0F/YyxBtHdmWitqgDPn6VgXQeKhiNC1fMwYDpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,13 +15,18 @@
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
+    "@invertase/react-native-apple-authentication": "^2.4.0",
     "@react-native-community/netinfo": "^11.4.0",
+    "@react-native-firebase/app": "^21.0.0",
+    "@react-native-firebase/auth": "^21.0.0",
+    "@react-native-google-signin/google-signin": "^13.0.0",
     "@react-navigation/native": "^7.0.0",
     "@react-navigation/native-stack": "^7.0.0",
     "bignumber.js": "^9.1.2",
     "expo": "~52.0.0",
     "expo-asset": "~11.0.5",
     "expo-av": "~15.0.2",
+    "expo-build-properties": "^55.0.9",
     "expo-constants": "~17.0.0",
     "expo-crypto": "~14.0.0",
     "expo-dev-client": "~5.0.20",
@@ -37,11 +42,7 @@
     "react-native-safe-area-context": "4.14.1",
     "react-native-screens": "~4.5.0",
     "react-native-svg": "15.8.0",
-    "zustand": "^5.0.0",
-    "@react-native-firebase/app": "^21.0.0",
-    "@react-native-firebase/auth": "^21.0.0",
-    "@react-native-google-signin/google-signin": "^13.0.0",
-    "@invertase/react-native-apple-authentication": "^2.4.0"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary
- `expo-build-properties` was referenced in `app.config.ts` (PR #76) but never installed as a dependency
- Without it, `use_frameworks! :linkage => :static` was never added to the Podfile, so the `'FirebaseAuth/FirebaseAuth-Swift.h' file not found` error persisted
- This PR adds the missing npm dependency so the plugin actually runs during prebuild

## Test plan
- [ ] Run `npx eas build --platform ios --profile preview` and verify the build succeeds
- [ ] Verify `expo config` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)