### PR TITLE
fix: disable asyncpg statement cache for pgbouncer compatibility

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -61,6 +61,7 @@ async def run_async_migrations() -> None:
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        connect_args={"statement_cache_size": 0},
     )
 
     async with connectable.connect() as connection:

--- a/apps/api/src/coyo/db.py
+++ b/apps/api/src/coyo/db.py
@@ -15,6 +15,7 @@ def get_engine():
         settings.database_url,
         echo=settings.debug,
         pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
     )
 
 


### PR DESCRIPTION
## Summary

- Disable asyncpg prepared statement cache (`statement_cache_size=0`) in both `alembic/env.py` and `db.py`
- Fixes `DuplicatePreparedStatementError` when connecting through pgbouncer in transaction pool mode
- This was causing the deploy workflow to fail at the migration step

## Test plan

- [x] All 333 unit tests pass
- [ ] Re-run deploy workflow after merging to verify migrations succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)