### PR TITLE
fix: disable asyncpg statement cache for pgbouncer compatibility

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -61,6 +61,7 @@ async def run_async_migrations() -> None:
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        connect_args={"statement_cache_size": 0},
     )
 
     async with connectable.connect() as connection:

--- a/apps/api/src/coyo/db.py
+++ b/apps/api/src/coyo/db.py
@@ -15,6 +15,7 @@ def get_engine():
         settings.database_url,
         echo=settings.debug,
         pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
     )
 
 


### PR DESCRIPTION
## Summary

- Disable asyncpg prepared statement cache (`statement_cache_size=0`) in `alembic/env.py` and `db.py`
- Fixes `DuplicatePreparedStatementError` during deploy migrations caused by pgbouncer transaction pool mode

## Test plan

- [x] All 333 unit tests pass
- [ ] Deploy workflow succeeds after merge (migrations run without error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)