### PR TITLE
fix: update history list UI to use default logo icon and show date

### DIFF
--- a/apps/mobile/src/features/history/HistoryListScreen.tsx
+++ b/apps/mobile/src/features/history/HistoryListScreen.tsx
@@ -16,12 +16,12 @@ import { apiClient } from '@/api/client';
 import { Colors } from '@/constants/colors';
 import { Typography } from '@/constants/typography';
 import { t } from '@/i18n';
-import { findTopic } from '@/constants/topics';
-import { TopicIcon, TrashIcon, SpeechBubbleIcon, HintCircleIcon } from '@/components/icons';
+import { LogoIcon, TrashIcon, SpeechBubbleIcon, HintCircleIcon } from '@/components/icons';
 import { NavBar } from '@/components/NavBar';
 import type { RootStackParamList } from '@/navigation/types';
 import type { HistoryListItem, HistoryListResponse } from '@/types/conversation';
-import { formatDuration, formatTime, groupByDate } from './utils/format';
+import { findTopic } from '@/constants/topics';
+import { formatDateTime, groupByDate } from './utils/format';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'HistoryList'>;
 
@@ -41,8 +41,6 @@ const HistoryRow = memo(function HistoryRow({ item, onPress, onDelete }: History
 
   const topic = findTopic(item.topic);
   const topicLabel = topic?.label ?? item.topic;
-  const topicIcon = topic?.icon ?? 'globe';
-  const topicIconColor = topic?.iconColor ?? Colors.topicSports;
 
   const handlePress = useCallback(() => {
     if (swiped) {
@@ -112,16 +110,16 @@ const HistoryRow = memo(function HistoryRow({ item, onPress, onDelete }: History
           onPress={handlePress}
           onLongPress={handleLongPress}
           accessibilityRole="button"
-          accessibilityLabel={`${topicLabel}, ${formatDuration(item.durationSeconds)}`}
+          accessibilityLabel={`${topicLabel}, ${formatDateTime(item.startedAt)}`}
         >
           <View style={styles.rowLeft}>
             <View style={styles.topicIcon}>
-              <TopicIcon icon={topicIcon} size={20} color={topicIconColor} />
+              <LogoIcon width={22} height={11} color={Colors.buttonPrimaryBg} />
             </View>
             <View style={styles.rowInfo}>
               <Text style={styles.rowTopic}>{topicLabel}</Text>
               <Text style={styles.rowMeta}>
-                {formatDuration(item.durationSeconds)} · {formatTime(item.startedAt)}
+                {formatDateTime(item.startedAt)}
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/features/history/utils/format.test.ts
+++ b/apps/mobile/src/features/history/utils/format.test.ts
@@ -1,6 +1,7 @@
 import {
   formatDuration,
   formatTime,
+  formatDateTime,
   getSectionTitle,
   groupByDate,
   formatDetailHeader,
@@ -75,6 +76,32 @@ describe('formatTime', () => {
     const date = new Date(2026, 0, 15, 23, 59, 0);
     const result = formatTime(date.toISOString());
     expect(result).toBe('11:59 PM');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('formats date with year, month name, day, and time', () => {
+    const date = new Date(2026, 1, 12, 9, 42, 0);
+    const result = formatDateTime(date.toISOString());
+    expect(result).toBe('February 12, 2026, 9:42 AM');
+  });
+
+  it('formats PM time correctly', () => {
+    const date = new Date(2026, 1, 11, 20, 15, 0);
+    const result = formatDateTime(date.toISOString());
+    expect(result).toBe('February 11, 2026, 8:15 PM');
+  });
+
+  it('formats midnight correctly', () => {
+    const date = new Date(2026, 1, 10, 0, 30, 0);
+    const result = formatDateTime(date.toISOString());
+    expect(result).toBe('February 10, 2026, 12:30 AM');
+  });
+
+  it('formats July correctly', () => {
+    const date = new Date(2025, 6, 4, 15, 0, 0);
+    const result = formatDateTime(date.toISOString());
+    expect(result).toBe('July 4, 2025, 3:00 PM');
   });
 });
 

--- a/apps/mobile/src/features/history/utils/format.ts
+++ b/apps/mobile/src/features/history/utils/format.ts
@@ -20,6 +20,16 @@ export function formatTime(isoString: string): string {
   return `${displayHour}:${minutes} ${ampm}`;
 }
 
+export function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const time = formatTime(isoString);
+  const monthName = t(`dates.months.${date.getMonth()}`);
+  return t('dates.dateTimeFormat', { year, month, day, time, monthName });
+}
+
 export function getSectionTitle(isoString: string, now?: Date): string {
   const date = new Date(isoString);
   const reference = now ?? new Date();
@@ -78,11 +88,7 @@ export function formatDetailHeader(
   else if (diffDays === 1) datePart = t('dates.yesterday');
   else datePart = t('dates.dateFormat', { month: date.getMonth() + 1, day: date.getDate() });
 
-  const hours = date.getHours();
-  const minutes = date.getMinutes().toString().padStart(2, '0');
-  const ampm = hours >= 12 ? 'PM' : 'AM';
-  const displayHour = hours % 12 || 12;
-  const timePart = `${displayHour}:${minutes} ${ampm}`;
+  const timePart = formatTime(isoString);
 
   const durationPart = formatDuration(durationSeconds);
 

--- a/apps/mobile/src/i18n/locales/en.ts
+++ b/apps/mobile/src/i18n/locales/en.ts
@@ -104,6 +104,8 @@ const en = {
     today: 'Today',
     yesterday: 'Yesterday',
     dateFormat: '{{month}}/{{day}}',
+    dateTimeFormat: '{{monthName}} {{day}}, {{year}}, {{time}}',
+    months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
   },
 
   // History - Duration Formats

--- a/apps/mobile/src/i18n/locales/ja.ts
+++ b/apps/mobile/src/i18n/locales/ja.ts
@@ -104,6 +104,8 @@ const ja = {
     today: '今日',
     yesterday: '昨日',
     dateFormat: '{{month}}月{{day}}日',
+    dateTimeFormat: '{{year}}年{{month}}月{{day}}日 {{time}}',
+    months: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
   },
 
   // History - Duration Formats


### PR DESCRIPTION
## Summary
- Replace topic-specific icons with fixed Coyo logo icon in history list rows
- Remove duration display from history row metadata
- Add date+time display (EN: "July 4, 2025, 3:00 PM", JA: "2025年7月4日 3:00 PM")
- Refactor `formatDetailHeader` to reuse `formatTime` (remove duplicated logic)

## Test plan
- [x] Unit tests: 32/32 passed (including 4 new `formatDateTime` tests)
- [x] Test coverage: Stmts 100%, Branch 89%, Funcs 100%, Lines 100%
- [x] TypeScript build: passed
- [x] Expo export: passed
- [x] Code review (code-reviewer agent): Approved
- [x] Security review (security-reviewer agent): Approved (0 critical/high/medium issues)
- [x] E2E test iOS (Maestro): passed
- [x] E2E test Android (Maestro): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)