### PR TITLE
feat: add make dev-stop and stale process guard for worktree cleanup

### DIFF
--- a/.claude/rules/common/git.md
+++ b/.claude/rules/common/git.md
@@ -156,11 +156,15 @@ PR creation and worktree cleanup are an **atomic operation** — one MUST NOT ha
    ```bash
    cd <repo-root>
    ```
-3. Remove the worktree:
+3. Stop dev processes that may be running from the worktree:
+   ```bash
+   make dev-stop
+   ```
+4. Remove the worktree:
    ```bash
    git worktree remove .claude/worktrees/<dir-name>
    ```
-4. Delete the local branch:
+5. Delete the local branch:
    ```bash
    git branch -d <branch-name>
    ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-mobile dev-api dev-ios dev-android dev-both lint lint-mobile lint-api test test-mobile test-api e2e e2e-ios e2e-android migrate migrate-new docker-up docker-down docker-reset generate-api-types db-clean-users
+.PHONY: dev-mobile dev-api dev-ios dev-android dev-both dev-stop lint lint-mobile lint-api test test-mobile test-api e2e e2e-ios e2e-android migrate migrate-new docker-up docker-down docker-reset generate-api-types db-clean-users
 
 # Infrastructure
 docker-up:
@@ -30,6 +30,9 @@ dev-android:
 
 dev-both:
 	cd apps/mobile && ./run-dev.sh both
+
+dev-stop:
+	./scripts/stop-dev.sh
 
 # Linting
 lint: lint-mobile lint-api

--- a/apps/mobile/e2e/run-e2e.sh
+++ b/apps/mobile/e2e/run-e2e.sh
@@ -54,6 +54,10 @@ require_environment() {
   local target="$1"
   local errors=0
 
+  # Kill stale dev processes running from deleted worktree directories
+  validate_port_process "$API_PORT" "API"
+  validate_port_process "$METRO_PORT" "Metro"
+
   # Maestro CLI
   if ! command -v maestro &>/dev/null; then
     err "Maestro CLI not found. Install with: curl -Ls \"https://get.maestro.mobile.dev\" | bash"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -12,11 +12,13 @@
 #
 # This file exports:
 #   Functions: init_log, log, warn, err, info,
-#              init_worktree, kill_existing_metro, ensure_docker,
-#              ensure_backend, get_booted_ios_udid, get_android_emulator_id,
-#              setup_adb_reverse, boot_ios_simulator, boot_android_emulator,
-#              wait_for_url
-#   Variables: _MAIN_REPO_ROOT, _COMPOSE_PROJECT, API_PORT, API_HEALTH_URL
+#              init_worktree, validate_port_process, kill_port_processes,
+#              kill_existing_metro, ensure_docker, ensure_backend,
+#              get_booted_ios_udid,
+#              get_android_emulator_id, setup_adb_reverse,
+#              boot_ios_simulator, boot_android_emulator, wait_for_url
+#   Variables: _MAIN_REPO_ROOT, _COMPOSE_PROJECT, API_PORT, METRO_PORT,
+#              API_HEALTH_URL
 
 # Guard: do nothing if executed directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -29,6 +31,7 @@ fi
 # ===========================================================================
 
 API_PORT=8000
+METRO_PORT=8081
 API_HEALTH_URL="http://localhost:${API_PORT}/health"
 
 # Initialized by init_worktree; callers may read these
@@ -89,30 +92,90 @@ wait_for_url() {
 }
 
 # ===========================================================================
-# Metro
+# Stale process detection
 # ===========================================================================
 
-# Kill any existing Metro process on port 8081
-kill_existing_metro() {
+# validate_port_process PORT LABEL
+# Check if a process listening on PORT has a valid (existing) working directory.
+# If the cwd no longer exists (e.g., a deleted git worktree), kill the process.
+# This prevents stale dev processes from serving outdated code.
+# Returns 0 always (best-effort guard).
+validate_port_process() {
+  local port="$1" label="$2"
   local pids
-  pids=$(lsof -ti :8081 2>/dev/null || true)
+  pids=$(lsof -ti :"$port" 2>/dev/null || true)
+  if [[ -z "$pids" ]]; then
+    return 0
+  fi
+
+  # Check each PID individually — only kill processes whose cwd no longer exists
+  local stale_pids=()
+  local pid cwd
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep '^n' | sed 's/^n//' || true)
+    if [[ -n "$cwd" && ! -d "$cwd" ]]; then
+      stale_pids+=("$pid")
+      warn "Stale $label process (PID: $pid) running from deleted directory: $cwd"
+    fi
+  done <<< "$pids"
+
+  if [[ ${#stale_pids[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  warn "Killing ${#stale_pids[@]} stale $label process(es)..."
+  printf '%s\n' "${stale_pids[@]}" | xargs kill 2>/dev/null || true
+  sleep 2
+  # Force-kill any that survived
+  local survivor
+  for pid in "${stale_pids[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      survivor=true
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  [[ "${survivor:-}" == "true" ]] && sleep 1
+  log "Stale $label process(es) terminated."
+
+  return 0
+}
+
+# ===========================================================================
+# Process management
+# ===========================================================================
+
+# kill_port_processes PORT LABEL
+# Kill all processes listening on PORT with SIGTERM, then SIGKILL if needed.
+# Logs what it does. No-op if nothing is listening.
+kill_port_processes() {
+  local port="$1" label="$2"
+  local pids
+  pids=$(lsof -ti :"$port" 2>/dev/null || true)
   if [[ -z "$pids" ]]; then
     return
   fi
 
-  warn "Killing existing Metro process on port 8081 (PIDs: $pids)"
-  # Stage 1: graceful SIGTERM
+  warn "Killing $label on port $port (PIDs: $pids)"
   echo "$pids" | xargs kill 2>/dev/null || true
   sleep 2
 
-  # Stage 2: SIGKILL anything that didn't exit
   local remaining
-  remaining=$(lsof -ti :8081 2>/dev/null || true)
+  remaining=$(lsof -ti :"$port" 2>/dev/null || true)
   if [[ -n "$remaining" ]]; then
-    warn "Metro did not exit after SIGTERM; force-killing (PIDs: $remaining)"
+    warn "$label did not exit after SIGTERM; force-killing (PIDs: $remaining)"
     echo "$remaining" | xargs kill -9 2>/dev/null || true
     sleep 1
   fi
+}
+
+# ===========================================================================
+# Metro
+# ===========================================================================
+
+# Kill any existing Metro process on port $METRO_PORT
+kill_existing_metro() {
+  kill_port_processes "$METRO_PORT" "Metro"
 }
 
 # ===========================================================================
@@ -166,6 +229,9 @@ _BACKEND_PID=""
 
 ensure_backend() {
   _BACKEND_PID=""
+
+  # Kill stale API process running from a deleted worktree directory
+  validate_port_process "$API_PORT" "API"
 
   if curl -sf --max-time 3 "$API_HEALTH_URL" > /dev/null 2>&1; then
     log "Backend API already running."

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# stop-dev.sh — Stop dev environment processes (API + Metro)
+#
+# Usage:
+#   ./scripts/stop-dev.sh          # Stop all dev processes
+#   make dev-stop                  # Same, via Makefile
+#
+# Stops:
+#   - Backend API (uvicorn) on port 8000
+#   - Metro bundler (Expo) on port 8081
+#
+# Docker containers (Postgres, Redis) are NOT stopped — they are shared
+# infrastructure and cheap to keep running. Use `make docker-down` to stop them.
+#
+# Safe to run when no processes are running (exits cleanly).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+API_DIR="$REPO_ROOT/apps/api"
+
+# Source shared functions (provides API_PORT, METRO_PORT, kill_port_processes, logging)
+source "$REPO_ROOT/scripts/lib/common.sh"
+init_log "[stop]"
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+stop_service() {
+  local port="$1" label="$2"
+  local pids
+  pids=$(lsof -ti :"$port" 2>/dev/null || true)
+  if [[ -z "$pids" ]]; then
+    log "$label: not running."
+    return 0
+  fi
+  kill_port_processes "$port" "$label"
+  log "$label stopped."
+}
+
+echo ""
+stop_service "$API_PORT" "API (uvicorn)"
+stop_service "$METRO_PORT" "Metro bundler"
+echo ""
+log "Dev environment stopped."


### PR DESCRIPTION
## Summary

- Add `make dev-stop` command to stop dev environment processes (API + Metro)
- Add `validate_port_process()` guard that automatically detects and kills processes running from deleted git worktrees
- Update worktree cleanup rules to include `make dev-stop` step
- Refactor shared `kill_port_processes()` helper and add `METRO_PORT` constant

## Background

After worktree deletion, uvicorn and Metro processes started from the worktree continued running with a non-existent working directory, serving stale code. This caused `POST /api/conversations` to return 500 errors and 3 E2E test failures (see #85).

## Changes

| File | Change |
|---|---|
| `scripts/stop-dev.sh` | New script to stop API and Metro processes |
| `scripts/lib/common.sh` | Add `METRO_PORT`, `validate_port_process()`, `kill_port_processes()` |
| `apps/mobile/e2e/run-e2e.sh` | Add stale process validation in `require_environment()` |
| `Makefile` | Add `dev-stop` target |
| `.claude/rules/common/git.md` | Add `make dev-stop` to worktree cleanup steps |

## Test plan

- [x] `make dev-stop` kills running API and Metro processes
- [x] `make dev-stop` exits cleanly when no processes are running
- [x] `validate_port_process` detects and kills processes with deleted cwd
- [x] `validate_port_process` leaves processes with valid cwd untouched
- [x] All scripts pass `bash -n` syntax check
- [x] Code review: approved
- [x] Security review: approved (Medium #1 addressed — per-PID cwd check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)