### PR TITLE
Add CI gate between PR creation and worktree cleanup

### DIFF
--- a/.claude/rules/common/git.md
+++ b/.claude/rules/common/git.md
@@ -142,11 +142,26 @@ When creating PRs:
 3. Draft comprehensive PR summary (in the same language as `README.md`)
 4. Include test plan with TODOs
 5. Push with `-u` flag if new branch
-6. Clean up worktree — see **Worktree Cleanup (MUST)** below
+6. Wait for CI — see **CI Gate (MUST)** below
+7. Clean up worktree — see **Worktree Cleanup (MUST)** below
+
+## CI Gate (MUST)
+
+After creating a PR, Claude MUST verify that all CI checks pass before proceeding to worktree cleanup.
+
+1. Poll CI status using `gh pr checks <pr-number> --watch` or equivalent until all checks complete
+2. If **all checks pass**: proceed to **Worktree Cleanup**
+3. If **any check fails**:
+   - Inspect the failure logs: `gh pr checks <pr-number>` and `gh run view <run-id> --log-failed`
+   - Fix the issue in the worktree, commit, and push
+   - Return to step 1 (re-poll CI)
+   - Do NOT proceed to cleanup until all checks are green
+
+> **Gate**: Worktree cleanup is BLOCKED until all CI checks pass. Do NOT clean up the worktree while CI is failing — the worktree is needed to apply fixes.
 
 ## Worktree Cleanup (MUST)
 
-PR creation and worktree cleanup are an **atomic operation** — one MUST NOT happen without the other. Immediately after a PR is created, Claude MUST execute the following cleanup steps before responding to the user.
+PR creation, CI verification, and worktree cleanup are an **atomic operation** — none may be skipped. After a PR is created **and all CI checks pass**, Claude MUST execute the following cleanup steps before responding to the user.
 
 1. Verify the worktree exists:
    ```bash

--- a/.claude/rules/common/workflow.md
+++ b/.claude/rules/common/workflow.md
@@ -113,7 +113,8 @@ Design elements are executed sequentially. Skip elements not relevant to the fea
 ### Phase 5: Finalize
 
 14. **Commit & Push** (BLOCKED until steps 11–13 are complete — see gate condition above)
-15. **Documentation** (significant changes only)
+15. **CI Gate** — Wait for all CI checks to pass (see [git.md](git.md) "CI Gate"). Fix failures and re-push until green.
+16. **Documentation** (significant changes only)
     - Use **doc-updater** to update codemaps and docs
 
 ---
@@ -144,6 +145,7 @@ Reproduce-First: confirm the bug before fixing.
 > **Gate: Commit**: Steps 5, 6, and 7 MUST ALL be complete. ALL reviewer results must be collected and issues addressed. E2E must pass on all target platforms.
 
 8. **Commit & Push** (BLOCKED until gate condition above is met)
+9. **CI Gate** — Wait for all CI checks to pass (see [git.md](git.md) "CI Gate"). Fix failures and re-push until green.
 
 ---
 
@@ -170,6 +172,7 @@ Safety-Net-First: ensure existing behavior is protected.
 > **Gate: Commit**: Steps 4, 5, 6, and 7 MUST ALL be complete. ALL reviewer results must be collected and issues addressed. E2E must pass on all target platforms.
 
 8. **Commit & Push** (BLOCKED until gate condition above is met)
+9. **CI Gate** — Wait for all CI checks to pass (see [git.md](git.md) "CI Gate"). Fix failures and re-push until green.
 
 ---
 
@@ -197,6 +200,7 @@ Schema-First: design the schema before writing application code.
 > **Gate: Commit**: Steps 5 and 6 MUST ALL be complete. ALL reviewer results must be collected and issues addressed. E2E must pass on all target platforms.
 
 7. **Commit & Push** (BLOCKED until gate condition above is met)
+8. **CI Gate** — Wait for all CI checks to pass (see [git.md](git.md) "CI Gate"). Fix failures and re-push until green.
 
 ---
 
@@ -208,4 +212,5 @@ Lightweight flow for documentation-only changes.
 2. **Update** - Use **doc-updater** to regenerate codemaps and refresh docs
 3. **Verify** - Confirm links work and examples are current
 4. **Commit & Push**
+5. **CI Gate** — Wait for all CI checks to pass (see [git.md](git.md) "CI Gate"). Fix failures and re-push until green.
 


### PR DESCRIPTION
## Summary
- Add a **CI Gate** step to all workflows (Feature, Bugfix, Refactor, DB Change, Docs) in `workflow.md`
- Add a **CI Gate (MUST)** section to `git.md` with detailed instructions for polling CI, inspecting failures, and fixing before cleanup
- Update **Worktree Cleanup** precondition: cleanup is now blocked until all CI checks pass

## Motivation
Previously, worktree cleanup happened immediately after PR creation regardless of CI status. If CI failed, the worktree (needed to apply fixes) was already removed, requiring manual recreation.

## Test plan
- [ ] Verify `git.md` CI Gate section has clear instructions for polling and fixing failures
- [ ] Verify all 5 workflow types in `workflow.md` include the CI Gate step
- [ ] Verify Worktree Cleanup section references CI gate as a precondition

🤖 Generated with [Claude Code](https://claude.com/claude-code)