### PR TITLE
fix: add pulsing animation to AI typing indicator dots

### DIFF
--- a/apps/mobile/src/features/talk/components/MessageBubble.tsx
+++ b/apps/mobile/src/features/talk/components/MessageBubble.tsx
@@ -109,6 +109,11 @@ export const TypingBubble = memo(function TypingBubble({ text }: TypingBubblePro
  */
 export const AiTypingBubble = memo(function AiTypingBubble() {
   const springAnim = useRef(new Animated.Value(0)).current;
+  const dotAnims = useRef([
+    new Animated.Value(0),
+    new Animated.Value(0),
+    new Animated.Value(0),
+  ]).current;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -121,6 +126,44 @@ export const AiTypingBubble = memo(function AiTypingBubble() {
     }, 400);
     return () => clearTimeout(timer);
   }, [springAnim]);
+
+  useEffect(() => {
+    const CYCLE_MS = 1400;
+    const FADE_MS = CYCLE_MS * 0.4;   // 560ms fade in / fade out
+    const PAUSE_MS = CYCLE_MS * 0.2;  // 280ms hold at rest
+    const STAGGER_MS = 200;
+
+    const loops = dotAnims.map((anim, i) => {
+      const loop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(anim, {
+            toValue: 1,
+            duration: FADE_MS,
+            useNativeDriver: true,
+          }),
+          Animated.timing(anim, {
+            toValue: 0,
+            duration: FADE_MS,
+            useNativeDriver: true,
+          }),
+          Animated.timing(anim, {
+            toValue: 0,
+            duration: PAUSE_MS,
+            useNativeDriver: true,
+          }),
+        ]),
+      );
+      const delayTimer = setTimeout(() => loop.start(), STAGGER_MS * i);
+      return { loop, delayTimer };
+    });
+
+    return () => {
+      loops.forEach(({ loop, delayTimer }) => {
+        clearTimeout(delayTimer);
+        loop.stop();
+      });
+    };
+  }, [dotAnims]);
 
   const animStyle = {
     opacity: springAnim,
@@ -139,14 +182,33 @@ export const AiTypingBubble = memo(function AiTypingBubble() {
     <View
       style={styles.aiContainer}
       accessibilityRole="text"
-      accessibilityLabel="Coyo is typing"
+      accessibilityLabel={t('talk.aiTyping')}
     >
       <CoyoAvatar size={28} variant="sub" />
       <Animated.View style={[styles.aiBubble, styles.typingIndicatorBubble, animStyle]}>
         <View style={styles.typingDots}>
-          <View style={[styles.typingDot, styles.typingDotMuted]} />
-          <View style={styles.typingDot} />
-          <View style={[styles.typingDot, styles.typingDotMuted]} />
+          {dotAnims.map((anim, i) => (
+            <Animated.View
+              key={i}
+              style={[
+                styles.typingDot,
+                {
+                  opacity: anim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0.4, 1],
+                  }),
+                  transform: [
+                    {
+                      scale: anim.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [0.6, 1],
+                      }),
+                    },
+                  ],
+                },
+              ]}
+            />
+          ))}
         </View>
       </Animated.View>
     </View>
@@ -286,8 +348,5 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     backgroundColor: Colors.chevron,
-  },
-  typingDotMuted: {
-    opacity: 0.6,
   },
 });

--- a/apps/mobile/src/i18n/locales/en.ts
+++ b/apps/mobile/src/i18n/locales/en.ts
@@ -41,6 +41,7 @@ const en = {
     lessThanMinute: 'Less than 1 min',
     minutesDuration: '{{mins}} min',
     greetingLoading: 'Coyo is preparing to talk...',
+    aiTyping: 'Coyo is typing',
   },
 
   // Talk - Corrections

--- a/apps/mobile/src/i18n/locales/ja.ts
+++ b/apps/mobile/src/i18n/locales/ja.ts
@@ -41,6 +41,7 @@ const ja = {
     lessThanMinute: '1分未満',
     minutesDuration: '{{mins}}分間',
     greetingLoading: 'Coyo が準備中...',
+    aiTyping: 'Coyo が入力中',
   },
 
   // Talk - Corrections


### PR DESCRIPTION
## Summary
- Replace static dots in `AiTypingBubble` with staggered pulsing animation (scale 0.6→1→0.6, opacity 0.4→1→0.4, 1.4s cycle, 200ms stagger)
- Use native driver for dot animations for optimal performance
- Move hardcoded accessibility label to i18n (`talk.aiTyping` in en/ja)
- Remove unused `typingDotMuted` style

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Code review — approved
- [x] Security review — approved (no security surface)
- [x] iOS E2E — 7/8 passed (`voice-conversation` failure is pre-existing, unrelated)
- [x] Android E2E — `auth-sign-in` + `start-conversation` passed
- [x] Visual confirmation on iOS Simulator — dots pulse in sequence
- [x] Visual confirmation on Android Emulator — dots pulse in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)