### PR TITLE
fix: wait for idle state in voice-conversation E2E test

### DIFF
--- a/apps/mobile/e2e/voice-conversation.yaml
+++ b/apps/mobile/e2e/voice-conversation.yaml
@@ -61,10 +61,10 @@ appId: to.coyo.app
 - tapOn:
     id: "send-recording"
 
-# Wait for turn to complete (record button reappears when idle)
+# Wait for turn to complete (idle hint text only appears when not streaming)
 - extendedWaitUntil:
     visible:
-      id: "record-button"
+      text: "Press Record to start speaking"
     timeout: 60000
 
 - takeScreenshot: "voice-02-turn1-complete"
@@ -90,10 +90,10 @@ appId: to.coyo.app
 - tapOn:
     id: "send-recording"
 
-# Wait for turn to complete
+# Wait for turn to complete (idle hint text only appears when not streaming)
 - extendedWaitUntil:
     visible:
-      id: "record-button"
+      text: "Press Record to start speaking"
     timeout: 60000
 
 - takeScreenshot: "voice-03-turn3-complete"
@@ -113,9 +113,11 @@ appId: to.coyo.app
       - tapOn:
           id: "correction-toggle"
 
-      # Verify the expanded card with corrected text and explanation
-      - assertVisible:
-          id: "correction-card"
+      # Wait for the expand animation (300ms) to complete
+      - extendedWaitUntil:
+          visible:
+            id: "correction-card"
+          timeout: 10000
       - assertVisible:
           id: "correction-corrected-text"
       - assertVisible:
@@ -127,9 +129,11 @@ appId: to.coyo.app
       - tapOn:
           id: "correction-toggle"
 
-      # Verify the expanded card is no longer visible
-      - assertNotVisible:
-          id: "correction-card"
+      # Wait for the collapse animation to finish and card to unmount
+      - extendedWaitUntil:
+          notVisible:
+            id: "correction-card"
+          timeout: 5000
 
       - takeScreenshot: "voice-03d-correction-collapsed"
 


### PR DESCRIPTION
## Summary
- Fixed voice-conversation E2E test that was skipping correction-card verification due to premature turn completion detection
- Root cause: `RecordButton` uses the same testID (`record-button`) in both processing and idle states, so `extendedWaitUntil: id: record-button` passed immediately without waiting for the turn pipeline to finish
- Changed wait condition to use idle hint text (`"Press Record to start speaking"`) which only appears when the conversation is truly idle
- Replaced `assertVisible`/`assertNotVisible` with `extendedWaitUntil` for correction-card expand/collapse to handle the 300ms animation

## Test plan
- [x] E2E test passes on iOS Simulator
- [x] E2E test passes on Android Emulator
- [x] Correction card expand/collapse verified in screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)