### PR TITLE
fix: auto sign-in for E2E flows when app starts unauthenticated

### DIFF
--- a/apps/mobile/e2e/app-launch.yaml
+++ b/apps/mobile/e2e/app-launch.yaml
@@ -9,6 +9,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 # On Android emulators, the Expo dev client cold start can be slow.
 - extendedWaitUntil:

--- a/apps/mobile/e2e/feedback-return-home.yaml
+++ b/apps/mobile/e2e/feedback-return-home.yaml
@@ -22,6 +22,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/e2e/helpers/ensure-signed-in.yaml
+++ b/apps/mobile/e2e/helpers/ensure-signed-in.yaml
@@ -1,0 +1,31 @@
+# ensure-signed-in.yaml
+# Helper flow: ensures the app is signed in before a test flow runs.
+#
+# If the Welcome screen is visible (unauthenticated), signs in with E2E
+# test user credentials. If already on the Home screen, this is a no-op.
+#
+# Prerequisites:
+# - App must be launched before calling this helper (launchApp)
+# - E2E test user must exist in Firebase with email_verified=True
+#   (created by: apps/api/scripts/create_e2e_user.py)
+#
+# Usage (in any flow that requires authentication):
+#   - launchApp:
+#       clearState: false
+#   - runFlow:
+#       file: helpers/ensure-signed-in.yaml
+#
+# This file is NOT listed in config.yaml and is NOT a test flow.
+appId: to.coyo.app
+---
+# Wait for the app to finish its initial loading and auth state resolution.
+# After this, either the Welcome screen or Home screen will be visible.
+- waitForAnimationToEnd
+
+# If the Welcome screen is visible, the user is not signed in.
+# Run the sign-in flow to authenticate with the E2E test user.
+- runFlow:
+    when:
+      visible:
+        id: "welcome-get-started"
+    file: sign-in.yaml

--- a/apps/mobile/e2e/history-empty-state.yaml
+++ b/apps/mobile/e2e/history-empty-state.yaml
@@ -11,6 +11,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/e2e/home-topic-cards.yaml
+++ b/apps/mobile/e2e/home-topic-cards.yaml
@@ -11,6 +11,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 # On Android emulators, the Expo dev client cold start can be slow.
 - extendedWaitUntil:

--- a/apps/mobile/e2e/navigate-to-history.yaml
+++ b/apps/mobile/e2e/navigate-to-history.yaml
@@ -10,6 +10,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/e2e/start-conversation.yaml
+++ b/apps/mobile/e2e/start-conversation.yaml
@@ -9,6 +9,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 # Wait for the Home screen to fully render.
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/e2e/voice-conversation.yaml
+++ b/apps/mobile/e2e/voice-conversation.yaml
@@ -21,6 +21,10 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Ensure signed in (handles unauthenticated state when running flow individually)
+- runFlow:
+    file: helpers/ensure-signed-in.yaml
+
 - extendedWaitUntil:
     visible:
       id: "topic-sports"


### PR DESCRIPTION
## Summary
- Add `helpers/ensure-signed-in.yaml` helper that conditionally signs in with the E2E test user when the Welcome screen is detected after app launch
- Include the helper in all 7 non-auth E2E flows (`app-launch`, `home-topic-cards`, `navigate-to-history`, `history-empty-state`, `start-conversation`, `feedback-return-home`, `voice-conversation`)
- When already signed in, the helper is a no-op (SKIPPED) — no overhead for the full test suite

## Test plan
- [x] Verified on iOS Simulator with **authenticated state**: `ensure-signed-in` correctly SKIPs sign-in
- [x] Verified on iOS Simulator with **unauthenticated state** (erased simulator): `ensure-signed-in` detects Welcome screen and runs full sign-in flow
- [x] Verified all 8 flows pass in full suite run (flaky failures are pre-existing parallel execution issues, not related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)