### PR TITLE
feat: add interest extraction pipeline (Pipeline A)

### DIFF
--- a/apps/api/alembic/versions/20260320_000000_0007_add_user_interests.py
+++ b/apps/api/alembic/versions/20260320_000000_0007_add_user_interests.py
@@ -1,0 +1,87 @@
+"""Add user_interests table and supporting columns.
+
+Creates:
+- user_interests: stores extracted interest keywords with 2-layer weight model
+- users.conversation_count: tracks total completed conversations for gap calculation
+- conversations.interests_extracted: idempotency flag for extraction
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-03-20 00:00:00+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # -- user_interests table -------------------------------------------------
+    op.create_table(
+        "user_interests",
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("keyword", sa.String(100), primary_key=True),
+        sa.Column(
+            "keyword_type",
+            sa.String(10),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "keyword_type IN ('topic', 'entity')",
+            name="ck_user_interests_keyword_type",
+        ),
+        sa.Column("is_news_relevant", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("total_mentions", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("short_term_stored", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("last_mentioned_conv_idx", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    # Note: no separate user_id index needed — composite PK (user_id, keyword)
+    # already covers user_id-only queries via leftmost prefix rule.
+
+    # -- users.conversation_count ---------------------------------------------
+    op.add_column(
+        "users",
+        sa.Column(
+            "conversation_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    # -- conversations.interests_extracted ------------------------------------
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "interests_extracted",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "interests_extracted")
+    op.drop_column("users", "conversation_count")
+    op.drop_table("user_interests")

--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     llm_conversation_model: str = "gpt-4.1-mini"
     llm_correction_model: str = "gpt-4.1-mini"
     llm_topic_model: str = "gpt-4.1-mini"
+    llm_interest_model: str = "gpt-5.4-nano"
 
     # Cron
     cron_secret: str | None = None

--- a/apps/api/src/coyo/main.py
+++ b/apps/api/src/coyo/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from coyo.middleware import setup_middleware
-from coyo.routers import auth, conversations, history, topics
+from coyo.routers import auth, conversations, history, interests, topics
 
 _is_prod = os.getenv("ENVIRONMENT") == "production"
 
@@ -45,6 +45,7 @@ setup_middleware(app)
 app.include_router(auth.router)
 app.include_router(conversations.router)
 app.include_router(history.router)
+app.include_router(interests.router)
 app.include_router(topics.router)
 
 

--- a/apps/api/src/coyo/models/__init__.py
+++ b/apps/api/src/coyo/models/__init__.py
@@ -9,6 +9,7 @@ from coyo.models.correction import CorrectionItem, TurnCorrection
 from coyo.models.topic_suggestion import TopicSuggestion, UserTopicSuggestion
 from coyo.models.turn import Turn
 from coyo.models.user import User, UserSettings
+from coyo.models.user_interest import UserInterest
 
 __all__ = [
     "Base",
@@ -18,6 +19,7 @@ __all__ = [
     "Turn",
     "TurnCorrection",
     "User",
+    "UserInterest",
     "UserSettings",
     "UserTopicSuggestion",
 ]

--- a/apps/api/src/coyo/models/conversation.py
+++ b/apps/api/src/coyo/models/conversation.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -70,6 +70,13 @@ class Conversation(BaseModel):
         nullable=True,
         default=None,
         index=True,
+    )
+    interests_extracted: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default="false",
+        default=False,
+        comment="Whether interest keywords have been extracted from this conversation",
     )
 
     # Relationships

--- a/apps/api/src/coyo/models/user.py
+++ b/apps/api/src/coyo/models/user.py
@@ -64,6 +64,14 @@ class User(BaseModel):
         comment="Authentication provider: email, google, apple",
     )
 
+    conversation_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default="0",
+        default=0,
+        comment="Total completed conversations, used for interest decay gap calculation",
+    )
+
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/apps/api/src/coyo/models/user_interest.py
+++ b/apps/api/src/coyo/models/user_interest.py
@@ -1,0 +1,71 @@
+"""UserInterest ORM model for tracking user interest keywords."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from coyo.models.base import Base
+
+
+class UserInterest(Base):
+    """Tracks an interest keyword extracted from a user's conversations.
+
+    Uses a 2-layer weight model:
+    - long_term: LONG_SCALE * log(1 + total_mentions)
+    - short_term: short_term_stored * SHORT_DECAY ^ gap
+    - effective_weight = long_term + short_term
+    """
+
+    __tablename__ = "user_interests"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "keyword_type IN ('topic', 'entity')",
+            name="ck_user_interests_keyword_type",
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    keyword: Mapped[str] = mapped_column(
+        String(100),
+        primary_key=True,
+    )
+    keyword_type: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        comment="'topic' or 'entity'",
+    )
+    is_news_relevant: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default="false",
+    )
+    total_mentions: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default="0",
+    )
+    short_term_stored: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        server_default="0.0",
+    )
+    last_mentioned_conv_idx: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default="0",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/apps/api/src/coyo/repositories/interest.py
+++ b/apps/api/src/coyo/repositories/interest.py
@@ -1,0 +1,182 @@
+"""Repository for UserInterest data access with 2-layer weight model."""
+
+import math
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.user_interest import UserInterest
+
+# 2-layer weight model parameters
+SHORT_DECAY: float = 0.85
+SHORT_BOOST: float = 1.0
+SHORT_CAP: float = 3.0
+LONG_SCALE: float = 0.5
+
+
+@dataclass(frozen=True)
+class InterestWithWeight:
+    """An interest keyword with its computed effective weight."""
+
+    keyword: str
+    keyword_type: str
+    is_news_relevant: bool
+    total_mentions: int
+    effective_weight: float
+    last_mentioned_conv_idx: int
+
+
+def compute_effective_weight(
+    total_mentions: int,
+    short_term_stored: float,
+    last_mentioned_conv_idx: int,
+    current_conv_idx: int,
+) -> float:
+    """Compute the effective weight for an interest keyword.
+
+    effective_weight = long_term + short_term
+    long_term  = LONG_SCALE * log(1 + total_mentions)
+    short_term = short_term_stored * SHORT_DECAY ^ gap
+    """
+    gap = max(0, current_conv_idx - last_mentioned_conv_idx)
+    long_term = LONG_SCALE * math.log(1 + total_mentions)
+    short_term = short_term_stored * (SHORT_DECAY**gap)
+    return long_term + short_term
+
+
+class InterestRepository:
+    """Encapsulates database operations for the UserInterest model."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_interest(
+        self,
+        *,
+        user_id: uuid.UUID,
+        keyword: str,
+        keyword_type: str,
+        is_news_relevant: bool,
+        current_conv_idx: int,
+    ) -> UserInterest:
+        """Insert or update an interest keyword with 2-layer model logic.
+
+        On insert: sets initial values.
+        On update: applies decay to short_term, then boosts.
+        """
+        keyword = keyword.lower().strip()
+        stmt = select(UserInterest).where(
+            UserInterest.user_id == user_id,
+            UserInterest.keyword == keyword,
+        )
+        result = await self._session.execute(stmt)
+        interest = result.scalar_one_or_none()
+
+        if interest is None:
+            interest = UserInterest(
+                user_id=user_id,
+                keyword=keyword,
+                keyword_type=keyword_type,
+                is_news_relevant=is_news_relevant,
+                total_mentions=1,
+                short_term_stored=min(SHORT_BOOST, SHORT_CAP),
+                last_mentioned_conv_idx=current_conv_idx,
+            )
+            self._session.add(interest)
+            try:
+                await self._session.flush()
+            except IntegrityError:
+                # Concurrent insert race — rollback and fall through to update
+                await self._session.rollback()
+                result = await self._session.execute(
+                    select(UserInterest).where(
+                        UserInterest.user_id == user_id,
+                        UserInterest.keyword == keyword,
+                    )
+                )
+                interest = result.scalar_one()
+                self._apply_mention(interest, is_news_relevant, current_conv_idx)
+                await self._session.flush()
+        else:
+            self._apply_mention(interest, is_news_relevant, current_conv_idx)
+            await self._session.flush()
+
+        return interest
+
+    @staticmethod
+    def _apply_mention(
+        interest: UserInterest,
+        is_news_relevant: bool,
+        current_conv_idx: int,
+    ) -> None:
+        """Apply a mention: decay short_term, boost, and update metadata."""
+        gap = max(0, current_conv_idx - interest.last_mentioned_conv_idx)
+        cur_short = interest.short_term_stored * (SHORT_DECAY**gap)
+
+        interest.total_mentions = interest.total_mentions + 1
+        interest.short_term_stored = min(cur_short + SHORT_BOOST, SHORT_CAP)
+        interest.last_mentioned_conv_idx = current_conv_idx
+        interest.is_news_relevant = is_news_relevant
+
+    @staticmethod
+    def _to_weighted(
+        interest: UserInterest,
+        current_conv_idx: int,
+    ) -> InterestWithWeight:
+        """Convert an ORM interest to a weighted dataclass."""
+        return InterestWithWeight(
+            keyword=interest.keyword,
+            keyword_type=interest.keyword_type,
+            is_news_relevant=interest.is_news_relevant,
+            total_mentions=interest.total_mentions,
+            effective_weight=compute_effective_weight(
+                interest.total_mentions,
+                interest.short_term_stored,
+                interest.last_mentioned_conv_idx,
+                current_conv_idx,
+            ),
+            last_mentioned_conv_idx=interest.last_mentioned_conv_idx,
+        )
+
+    async def get_interests_for_user(
+        self,
+        user_id: uuid.UUID,
+        current_conv_idx: int,
+    ) -> list[InterestWithWeight]:
+        """Get all interests for a user with computed effective weights."""
+        stmt = select(UserInterest).where(UserInterest.user_id == user_id)
+        result = await self._session.execute(stmt)
+        interests = result.scalars().all()
+
+        weighted = [self._to_weighted(i, current_conv_idx) for i in interests]
+        return sorted(weighted, key=lambda x: x.effective_weight, reverse=True)
+
+    async def get_top_interests(
+        self,
+        user_id: uuid.UUID,
+        current_conv_idx: int,
+        *,
+        keyword_type: str | None = None,
+        is_news_relevant: bool | None = None,
+        limit: int = 10,
+    ) -> list[InterestWithWeight]:
+        """Get top interests filtered by type and/or news relevance.
+
+        Used by Pipeline B to select keywords for personal topic generation.
+        """
+        conditions = [UserInterest.user_id == user_id]
+        if keyword_type is not None:
+            conditions.append(UserInterest.keyword_type == keyword_type)
+        if is_news_relevant is not None:
+            conditions.append(UserInterest.is_news_relevant == is_news_relevant)
+
+        stmt = select(UserInterest).where(*conditions)
+        result = await self._session.execute(stmt)
+        interests = result.scalars().all()
+
+        weighted = [self._to_weighted(i, current_conv_idx) for i in interests]
+        weighted.sort(key=lambda x: x.effective_weight, reverse=True)
+        return weighted[:limit]

--- a/apps/api/src/coyo/routers/interests.py
+++ b/apps/api/src/coyo/routers/interests.py
@@ -1,0 +1,41 @@
+"""User interest endpoints."""
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.dependencies import get_current_user, get_db
+from coyo.models.user import User
+from coyo.rate_limit import DEFAULT_RATE_LIMIT, limiter
+from coyo.repositories.interest import InterestRepository
+from coyo.schemas.interest import InterestResponse, InterestsListResponse
+
+router = APIRouter(prefix="/api/interests", tags=["interests"])
+
+
+@router.get("", response_model=InterestsListResponse)
+@limiter.limit(DEFAULT_RATE_LIMIT)
+async def get_interests(
+    request: Request,
+    limit: int = Query(default=50, ge=1, le=200),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InterestsListResponse:
+    """Get top interests for the current user, ordered by effective weight."""
+    repo = InterestRepository(db)
+    weighted = await repo.get_top_interests(
+        user.id, user.conversation_count, limit=limit
+    )
+
+    return InterestsListResponse(
+        interests=[
+            InterestResponse(
+                keyword=w.keyword,
+                keyword_type=w.keyword_type,
+                is_news_relevant=w.is_news_relevant,
+                total_mentions=w.total_mentions,
+                effective_weight=round(w.effective_weight, 4),
+                last_mentioned_conv_idx=w.last_mentioned_conv_idx,
+            )
+            for w in weighted
+        ]
+    )

--- a/apps/api/src/coyo/schemas/interest.py
+++ b/apps/api/src/coyo/schemas/interest.py
@@ -1,0 +1,22 @@
+"""Schemas for interest extraction endpoints."""
+
+from typing import Literal
+
+from coyo.schemas.base import CamelModel
+
+
+class InterestResponse(CamelModel):
+    """A single user interest with its computed weight."""
+
+    keyword: str
+    keyword_type: Literal["topic", "entity"]
+    is_news_relevant: bool
+    total_mentions: int
+    effective_weight: float
+    last_mentioned_conv_idx: int
+
+
+class InterestsListResponse(CamelModel):
+    """List of user interests ordered by effective weight."""
+
+    interests: list[InterestResponse]

--- a/apps/api/src/coyo/services/conversation.py
+++ b/apps/api/src/coyo/services/conversation.py
@@ -1,5 +1,6 @@
 """Service layer for conversation lifecycle management."""
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -13,6 +14,10 @@ from coyo.models.conversation import Conversation
 from coyo.models.correction import TurnCorrection
 from coyo.models.turn import Turn
 from coyo.repositories.conversation import ConversationRepository
+
+# Strong references to background tasks to prevent GC during execution.
+# See: https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+_background_tasks: set[asyncio.Task[None]] = set()
 
 ALLOWED_TOPICS: frozenset[str] = frozenset(
     {"sports", "business", "technology", "politics", "entertainment", "suggested"}
@@ -141,6 +146,16 @@ class ConversationService:
             score=None,
         )
         await self._session.commit()
+
+        # Background interest extraction (strong ref prevents GC)
+        from coyo.services.interest_extraction import InterestExtractionService
+
+        task = asyncio.create_task(
+            InterestExtractionService.extract_background(conversation_id, user_id)
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
         # update_on_end already checked for None via get_by_id above
         return conversation  # type: ignore[return-value]
 

--- a/apps/api/src/coyo/services/interest_extraction.py
+++ b/apps/api/src/coyo/services/interest_extraction.py
@@ -1,0 +1,226 @@
+"""Service for extracting user interests from conversation transcripts."""
+
+import uuid
+
+import structlog
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.config import get_settings
+from coyo.db import get_session_factory
+from coyo.models.conversation import Conversation
+from coyo.models.turn import Turn
+from coyo.models.user import User
+from coyo.repositories.interest import InterestRepository
+from coyo.services.llm.base import ChatMessage, ChatOptions
+from coyo.services.llm.openai_client import OpenAIClient
+
+logger = structlog.get_logger()
+
+_EXTRACTION_SYSTEM_PROMPT = """\
+Extract keywords from the English conversation.
+
+Return JSON:
+{
+  "topics": [
+    { "keyword": "tennis", "is_news_relevant": true },
+    { "keyword": "dining out", "is_news_relevant": false }
+  ],
+  "entities": [
+    { "keyword": "kei nishikori", "is_news_relevant": true },
+    { "keyword": "pasta carbonara", "is_news_relevant": false }
+  ]
+}
+Rules:
+- topics: broad subjects (max 3)
+- entities: specific proper nouns (max 5)
+- Deduplicate within each list
+- ALL keywords must be in English, lowercase
+- is_news_relevant: judge by the CATEGORY of the keyword, not by how \
+the user mentioned it. true for categories that regularly produce news \
+(sports, politics, economy, tech, entertainment, companies, athletes, etc.) \
+false for inherently evergreen categories (cooking, travel tips, daily \
+routines, language learning, personal hobbies with no pro scene). \
+Example: "tennis" is true (pro tournaments exist) even if the user said \
+"I play tennis" rather than "I watch tennis"."""
+
+
+_MAX_KEYWORD_LENGTH = 100
+MAX_TOPICS = 3
+MAX_ENTITIES = 5
+
+
+class KeywordItem(BaseModel):
+    """A single extracted keyword with news relevance flag."""
+
+    keyword: str
+    is_news_relevant: bool
+
+    @field_validator("keyword")
+    @classmethod
+    def normalize_keyword(cls, v: str) -> str:
+        v = v.lower().strip()
+        if len(v) > _MAX_KEYWORD_LENGTH:
+            v = v[:_MAX_KEYWORD_LENGTH]
+        return v
+
+
+class ExtractionResult(BaseModel):
+    """LLM response model for interest extraction."""
+
+    topics: list[KeywordItem] = []
+    entities: list[KeywordItem] = []
+
+
+class InterestExtractionService:
+    """Extracts interest keywords from conversations and persists them."""
+
+    @staticmethod
+    async def extract_background(
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Run interest extraction in an independent session.
+
+        Designed to be called via asyncio.create_task after conversation ends.
+        Errors are logged but never propagated.
+        """
+        try:
+            session_factory = get_session_factory()
+            async with session_factory() as session:
+                await InterestExtractionService._extract(
+                    session, conversation_id, user_id
+                )
+                await session.commit()
+        except Exception:
+            logger.exception(
+                "interest_extraction_failed",
+                conversation_id=str(conversation_id),
+                user_id=str(user_id),
+            )
+
+    @staticmethod
+    async def _extract(
+        session: AsyncSession,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Core extraction logic within a given session."""
+        # 1. Idempotency check
+        conversation = await session.get(Conversation, conversation_id)
+        if conversation is None:
+            logger.warning(
+                "interest_extraction_conversation_not_found",
+                conversation_id=str(conversation_id),
+            )
+            return
+        if conversation.interests_extracted:
+            logger.info(
+                "interest_extraction_already_done",
+                conversation_id=str(conversation_id),
+            )
+            return
+
+        # 2. Atomically increment conversation_count (prevents race condition)
+        stmt = (
+            update(User)
+            .where(User.id == user_id)
+            .values(conversation_count=User.conversation_count + 1)
+            .returning(User.conversation_count)
+        )
+        result = await session.execute(stmt)
+        row = result.one_or_none()
+        if row is None:
+            logger.warning(
+                "interest_extraction_user_not_found",
+                user_id=str(user_id),
+            )
+            return
+        current_conv_idx = row[0]
+
+        # 3. Build transcript (user turns only)
+        transcript = await InterestExtractionService._build_transcript(
+            session, conversation_id
+        )
+        if not transcript.strip():
+            logger.info(
+                "interest_extraction_empty_transcript",
+                conversation_id=str(conversation_id),
+            )
+            conversation.interests_extracted = True
+            await session.flush()
+            return
+
+        # 4. LLM extraction
+        extraction = await InterestExtractionService._call_llm(transcript)
+
+        # 5. Upsert interests
+        repo = InterestRepository(session)
+        seen_keywords: set[str] = set()
+
+        for item in extraction.topics[:MAX_TOPICS]:
+            if item.keyword and item.keyword not in seen_keywords:
+                seen_keywords.add(item.keyword)
+                await repo.upsert_interest(
+                    user_id=user_id,
+                    keyword=item.keyword,
+                    keyword_type="topic",
+                    is_news_relevant=item.is_news_relevant,
+                    current_conv_idx=current_conv_idx,
+                )
+
+        for item in extraction.entities[:MAX_ENTITIES]:
+            if item.keyword and item.keyword not in seen_keywords:
+                seen_keywords.add(item.keyword)
+                await repo.upsert_interest(
+                    user_id=user_id,
+                    keyword=item.keyword,
+                    keyword_type="entity",
+                    is_news_relevant=item.is_news_relevant,
+                    current_conv_idx=current_conv_idx,
+                )
+
+        # 6. Mark as extracted
+        conversation.interests_extracted = True
+        await session.flush()
+        logger.info(
+            "interest_extraction_complete",
+            conversation_id=str(conversation_id),
+            keywords_count=len(seen_keywords),
+        )
+
+    @staticmethod
+    async def _build_transcript(
+        session: AsyncSession,
+        conversation_id: uuid.UUID,
+    ) -> str:
+        """Build a transcript of user-only turns for the conversation."""
+        stmt = (
+            select(Turn.text)
+            .where(
+                Turn.conversation_id == conversation_id,
+                Turn.role == "user",
+            )
+            .order_by(Turn.sequence)
+        )
+        result = await session.execute(stmt)
+        texts = result.scalars().all()
+        return "\n".join(texts)
+
+    @staticmethod
+    async def _call_llm(transcript: str) -> ExtractionResult:
+        """Call LLM to extract topics and entities from transcript."""
+        settings = get_settings()
+        llm = OpenAIClient(model=settings.llm_interest_model)
+
+        messages = [
+            ChatMessage(role="system", content=_EXTRACTION_SYSTEM_PROMPT),
+            ChatMessage(role="user", content=transcript),
+        ]
+
+        return await llm.structured(
+            messages,
+            response_model=ExtractionResult,
+            options=ChatOptions(temperature=0.3, max_tokens=512),
+        )

--- a/apps/api/src/coyo/services/llm/openai_client.py
+++ b/apps/api/src/coyo/services/llm/openai_client.py
@@ -47,7 +47,7 @@ class OpenAIClient(LLMClient):
                 model=self._model,
                 messages=[{"role": m.role, "content": m.content} for m in messages],
                 temperature=opts.temperature,
-                max_tokens=opts.max_tokens,
+                max_completion_tokens=opts.max_tokens,
                 stream=True,
             )
             async for chunk in stream:
@@ -129,7 +129,7 @@ class OpenAIClient(LLMClient):
                 model=self._model,
                 messages=[{"role": m.role, "content": m.content} for m in messages],
                 temperature=opts.temperature,
-                max_tokens=opts.max_tokens,
+                max_completion_tokens=opts.max_tokens,
                 response_format={"type": "json_object"},
             )
             content = response.choices[0].message.content

--- a/apps/api/tests/unit/test_interest_extraction.py
+++ b/apps/api/tests/unit/test_interest_extraction.py
@@ -1,0 +1,354 @@
+"""Unit tests for the InterestExtractionService."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.conversation import Conversation
+from coyo.models.turn import Turn
+from coyo.models.user import User
+from coyo.models.user_interest import UserInterest
+from coyo.services.interest_extraction import (
+    ExtractionResult,
+    InterestExtractionService,
+    KeywordItem,
+)
+
+
+class TestKeywordItem:
+    """Tests for keyword normalization."""
+
+    @pytest.mark.unit
+    def test_keyword_lowercased(self):
+        item = KeywordItem(keyword="Tennis", is_news_relevant=True)
+        assert item.keyword == "tennis"
+
+    @pytest.mark.unit
+    def test_keyword_stripped(self):
+        item = KeywordItem(keyword="  tennis  ", is_news_relevant=True)
+        assert item.keyword == "tennis"
+
+    @pytest.mark.unit
+    def test_keyword_lowercased_and_stripped(self):
+        item = KeywordItem(keyword="  Kei Nishikori  ", is_news_relevant=True)
+        assert item.keyword == "kei nishikori"
+
+
+class TestExtractionResult:
+    """Tests for ExtractionResult schema."""
+
+    @pytest.mark.unit
+    def test_default_empty_lists(self):
+        result = ExtractionResult()
+        assert result.topics == []
+        assert result.entities == []
+
+    @pytest.mark.unit
+    def test_parse_valid_json(self):
+        result = ExtractionResult.model_validate_json(
+            '{"topics": [{"keyword": "tennis", "is_news_relevant": true}], '
+            '"entities": [{"keyword": "kei nishikori", "is_news_relevant": true}]}'
+        )
+        assert len(result.topics) == 1
+        assert result.topics[0].keyword == "tennis"
+        assert len(result.entities) == 1
+        assert result.entities[0].keyword == "kei nishikori"
+
+
+class TestBuildTranscript:
+    """Tests for transcript building."""
+
+    @pytest.mark.unit
+    async def test_build_transcript_user_turns_only(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        turns = [
+            Turn(
+                conversation_id=conversation.id,
+                role="user",
+                text="I love tennis.",
+                sequence=1,
+                correction_status="none",
+            ),
+            Turn(
+                conversation_id=conversation.id,
+                role="ai",
+                text="That's great! Do you play often?",
+                sequence=2,
+                correction_status="none",
+            ),
+            Turn(
+                conversation_id=conversation.id,
+                role="user",
+                text="Yes, I watch Kei Nishikori.",
+                sequence=3,
+                correction_status="none",
+            ),
+        ]
+        for turn in turns:
+            db_session.add(turn)
+        await db_session.flush()
+
+        transcript = await InterestExtractionService._build_transcript(
+            db_session, conversation.id
+        )
+        assert "I love tennis." in transcript
+        assert "Yes, I watch Kei Nishikori." in transcript
+        assert "That's great!" not in transcript
+
+    @pytest.mark.unit
+    async def test_build_transcript_empty_conversation(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        transcript = await InterestExtractionService._build_transcript(
+            db_session, conversation.id
+        )
+        assert transcript == ""
+
+
+class TestExtract:
+    """Tests for the core extraction logic."""
+
+    @pytest.mark.unit
+    async def test_extract_skips_already_extracted(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+            interests_extracted=True,
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        # Should return without calling LLM
+        await InterestExtractionService._extract(
+            db_session, conversation.id, test_user.id
+        )
+
+        # conversation_count should NOT be incremented
+        await db_session.refresh(test_user)
+        assert test_user.conversation_count == 0
+
+    @pytest.mark.unit
+    async def test_extract_skips_empty_transcript(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        await InterestExtractionService._extract(
+            db_session, conversation.id, test_user.id
+        )
+
+        await db_session.refresh(conversation)
+        assert conversation.interests_extracted is True
+        # conversation_count should still be incremented
+        await db_session.refresh(test_user)
+        assert test_user.conversation_count == 1
+
+    @pytest.mark.unit
+    async def test_extract_creates_interests(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        turn = Turn(
+            conversation_id=conversation.id,
+            role="user",
+            text="I love watching NBA basketball.",
+            sequence=1,
+            correction_status="none",
+        )
+        db_session.add(turn)
+        await db_session.flush()
+
+        mock_result = ExtractionResult(
+            topics=[KeywordItem(keyword="basketball", is_news_relevant=True)],
+            entities=[KeywordItem(keyword="nba", is_news_relevant=True)],
+        )
+
+        with patch.object(
+            InterestExtractionService,
+            "_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            await InterestExtractionService._extract(
+                db_session, conversation.id, test_user.id
+            )
+
+        await db_session.refresh(conversation)
+        assert conversation.interests_extracted is True
+
+        await db_session.refresh(test_user)
+        assert test_user.conversation_count == 1
+
+        stmt = select(UserInterest).where(UserInterest.user_id == test_user.id)
+        result = await db_session.execute(stmt)
+        interests = result.scalars().all()
+        assert len(interests) == 2
+        keywords = {i.keyword for i in interests}
+        assert "basketball" in keywords
+        assert "nba" in keywords
+
+    @pytest.mark.unit
+    async def test_extract_deduplicates_across_topics_and_entities(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        turn = Turn(
+            conversation_id=conversation.id,
+            role="user",
+            text="I love tennis.",
+            sequence=1,
+            correction_status="none",
+        )
+        db_session.add(turn)
+        await db_session.flush()
+
+        # "tennis" appears in both topics and entities
+        mock_result = ExtractionResult(
+            topics=[KeywordItem(keyword="tennis", is_news_relevant=True)],
+            entities=[KeywordItem(keyword="tennis", is_news_relevant=True)],
+        )
+
+        with patch.object(
+            InterestExtractionService,
+            "_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            await InterestExtractionService._extract(
+                db_session, conversation.id, test_user.id
+            )
+
+        stmt = select(UserInterest).where(UserInterest.user_id == test_user.id)
+        result = await db_session.execute(stmt)
+        interests = result.scalars().all()
+        # Should only be 1, not 2 (deduplicated)
+        assert len(interests) == 1
+        assert interests[0].keyword == "tennis"
+
+    @pytest.mark.unit
+    async def test_extract_limits_topics_and_entities(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        turn = Turn(
+            conversation_id=conversation.id,
+            role="user",
+            text="I talked about many things.",
+            sequence=1,
+            correction_status="none",
+        )
+        db_session.add(turn)
+        await db_session.flush()
+
+        # LLM returns more than limits
+        mock_result = ExtractionResult(
+            topics=[
+                KeywordItem(keyword=f"topic{i}", is_news_relevant=True)
+                for i in range(10)
+            ],
+            entities=[
+                KeywordItem(keyword=f"entity{i}", is_news_relevant=True)
+                for i in range(10)
+            ],
+        )
+
+        with patch.object(
+            InterestExtractionService,
+            "_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            await InterestExtractionService._extract(
+                db_session, conversation.id, test_user.id
+            )
+
+        stmt = select(UserInterest).where(UserInterest.user_id == test_user.id)
+        result = await db_session.execute(stmt)
+        interests = result.scalars().all()
+        # At most 3 topics + 5 entities = 8
+        assert len(interests) <= 8
+
+    @pytest.mark.unit
+    async def test_extract_nonexistent_conversation(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """Should not raise, just log and return."""
+        await InterestExtractionService._extract(
+            db_session, uuid.uuid4(), test_user.id
+        )
+
+    @pytest.mark.unit
+    async def test_extract_nonexistent_user(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """Should not raise, just log and return."""
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        await InterestExtractionService._extract(
+            db_session, conversation.id, uuid.uuid4()
+        )

--- a/apps/api/tests/unit/test_interest_repository.py
+++ b/apps/api/tests/unit/test_interest_repository.py
@@ -1,0 +1,334 @@
+"""Unit tests for the InterestRepository with 2-layer weight model."""
+
+import math
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.user import User
+from coyo.models.user_interest import UserInterest
+from coyo.repositories.interest import (
+    LONG_SCALE,
+    SHORT_BOOST,
+    SHORT_CAP,
+    SHORT_DECAY,
+    InterestRepository,
+    InterestWithWeight,
+    compute_effective_weight,
+)
+
+
+class TestComputeEffectiveWeight:
+    """Tests for the compute_effective_weight function."""
+
+    @pytest.mark.unit
+    def test_zero_mentions_zero_short_term(self):
+        weight = compute_effective_weight(
+            total_mentions=0,
+            short_term_stored=0.0,
+            last_mentioned_conv_idx=0,
+            current_conv_idx=0,
+        )
+        assert weight == 0.0
+
+    @pytest.mark.unit
+    def test_single_mention_no_gap(self):
+        weight = compute_effective_weight(
+            total_mentions=1,
+            short_term_stored=1.0,
+            last_mentioned_conv_idx=1,
+            current_conv_idx=1,
+        )
+        expected_long = LONG_SCALE * math.log(2)
+        expected_short = 1.0  # decay^0 = 1
+        assert weight == pytest.approx(expected_long + expected_short)
+
+    @pytest.mark.unit
+    def test_short_term_decays_with_gap(self):
+        weight = compute_effective_weight(
+            total_mentions=1,
+            short_term_stored=1.0,
+            last_mentioned_conv_idx=1,
+            current_conv_idx=4,
+        )
+        gap = 3
+        expected_long = LONG_SCALE * math.log(2)
+        expected_short = 1.0 * (SHORT_DECAY**gap)
+        assert weight == pytest.approx(expected_long + expected_short)
+
+    @pytest.mark.unit
+    def test_long_term_grows_logarithmically(self):
+        w1 = compute_effective_weight(1, 0.0, 0, 0)
+        w5 = compute_effective_weight(5, 0.0, 0, 0)
+        w10 = compute_effective_weight(10, 0.0, 0, 0)
+        # Logarithmic: growth rate decreases
+        assert w5 > w1
+        assert w10 > w5
+        assert (w10 - w5) < (w5 - w1)
+
+    @pytest.mark.unit
+    def test_negative_gap_treated_as_zero(self):
+        """If current_conv_idx < last_mentioned somehow, gap = 0."""
+        weight = compute_effective_weight(
+            total_mentions=1,
+            short_term_stored=1.0,
+            last_mentioned_conv_idx=5,
+            current_conv_idx=3,
+        )
+        expected_long = LONG_SCALE * math.log(2)
+        expected_short = 1.0  # gap clamped to 0
+        assert weight == pytest.approx(expected_long + expected_short)
+
+
+class TestInterestRepositoryUpsert:
+    """Tests for InterestRepository.upsert_interest."""
+
+    @pytest.mark.unit
+    async def test_insert_new_interest(self, db_session: AsyncSession, test_user: User):
+        repo = InterestRepository(db_session)
+        interest = await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        assert interest.keyword == "tennis"
+        assert interest.keyword_type == "topic"
+        assert interest.is_news_relevant is True
+        assert interest.total_mentions == 1
+        assert interest.short_term_stored == pytest.approx(SHORT_BOOST)
+        assert interest.last_mentioned_conv_idx == 1
+
+    @pytest.mark.unit
+    async def test_upsert_existing_interest_increments_mentions(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        interest = await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=2,
+        )
+        assert interest.total_mentions == 2
+
+    @pytest.mark.unit
+    async def test_upsert_applies_decay_and_boost(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        # Gap of 3 conversations
+        interest = await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=4,
+        )
+        expected_short = min(SHORT_BOOST * (SHORT_DECAY**3) + SHORT_BOOST, SHORT_CAP)
+        assert interest.short_term_stored == pytest.approx(expected_short)
+        assert interest.last_mentioned_conv_idx == 4
+
+    @pytest.mark.unit
+    async def test_upsert_respects_short_cap(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        # Rapidly mention the same keyword many times
+        for i in range(1, 10):
+            interest = await repo.upsert_interest(
+                user_id=test_user.id,
+                keyword="tennis",
+                keyword_type="topic",
+                is_news_relevant=True,
+                current_conv_idx=i,
+            )
+        assert interest.short_term_stored <= SHORT_CAP
+
+    @pytest.mark.unit
+    async def test_upsert_updates_news_relevance(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=False,
+            current_conv_idx=1,
+        )
+        interest = await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=2,
+        )
+        assert interest.is_news_relevant is True
+
+
+class TestInterestRepositoryQuery:
+    """Tests for InterestRepository query methods."""
+
+    @pytest.mark.unit
+    async def test_get_interests_for_user_empty(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        result = await repo.get_interests_for_user(test_user.id, 0)
+        assert result == []
+
+    @pytest.mark.unit
+    async def test_get_interests_sorted_by_weight(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        # tennis mentioned 5 times, cooking mentioned 1 time
+        for i in range(1, 6):
+            await repo.upsert_interest(
+                user_id=test_user.id,
+                keyword="tennis",
+                keyword_type="topic",
+                is_news_relevant=True,
+                current_conv_idx=i,
+            )
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="cooking",
+            keyword_type="topic",
+            is_news_relevant=False,
+            current_conv_idx=1,
+        )
+
+        result = await repo.get_interests_for_user(test_user.id, 5)
+        assert len(result) == 2
+        assert result[0].keyword == "tennis"
+        assert result[0].effective_weight > result[1].effective_weight
+
+    @pytest.mark.unit
+    async def test_get_top_interests_with_limit(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        for keyword in ["a", "b", "c", "d", "e"]:
+            await repo.upsert_interest(
+                user_id=test_user.id,
+                keyword=keyword,
+                keyword_type="topic",
+                is_news_relevant=True,
+                current_conv_idx=1,
+            )
+
+        result = await repo.get_top_interests(
+            test_user.id, 1, limit=3
+        )
+        assert len(result) == 3
+
+    @pytest.mark.unit
+    async def test_get_top_interests_filtered_by_type(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="kei nishikori",
+            keyword_type="entity",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+
+        topics = await repo.get_top_interests(
+            test_user.id, 1, keyword_type="topic"
+        )
+        entities = await repo.get_top_interests(
+            test_user.id, 1, keyword_type="entity"
+        )
+        assert len(topics) == 1
+        assert topics[0].keyword == "tennis"
+        assert len(entities) == 1
+        assert entities[0].keyword == "kei nishikori"
+
+    @pytest.mark.unit
+    async def test_get_top_interests_filtered_by_news_relevance(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="cooking",
+            keyword_type="topic",
+            is_news_relevant=False,
+            current_conv_idx=1,
+        )
+
+        news_relevant = await repo.get_top_interests(
+            test_user.id, 1, is_news_relevant=True
+        )
+        assert len(news_relevant) == 1
+        assert news_relevant[0].keyword == "tennis"
+
+    @pytest.mark.unit
+    async def test_different_users_have_separate_interests(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        other_user = User(
+            auth_uid="other-uid",
+            email="other@example.com",
+            auth_provider="email",
+        )
+        db_session.add(other_user)
+        await db_session.flush()
+
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        await repo.upsert_interest(
+            user_id=other_user.id,
+            keyword="chess",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+
+        user_interests = await repo.get_interests_for_user(test_user.id, 1)
+        other_interests = await repo.get_interests_for_user(other_user.id, 1)
+        assert len(user_interests) == 1
+        assert user_interests[0].keyword == "tennis"
+        assert len(other_interests) == 1
+        assert other_interests[0].keyword == "chess"

--- a/apps/api/tests/unit/test_interest_schemas.py
+++ b/apps/api/tests/unit/test_interest_schemas.py
@@ -1,0 +1,62 @@
+"""Unit tests for interest schema validation."""
+
+import pytest
+
+from coyo.schemas.interest import InterestResponse, InterestsListResponse
+
+
+class TestInterestResponse:
+    """Tests for InterestResponse schema."""
+
+    @pytest.mark.unit
+    def test_valid_construction(self):
+        resp = InterestResponse(
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            total_mentions=5,
+            effective_weight=2.1,
+            last_mentioned_conv_idx=12,
+        )
+        assert resp.keyword == "tennis"
+        assert resp.effective_weight == 2.1
+
+    @pytest.mark.unit
+    def test_camel_case_serialization(self):
+        resp = InterestResponse(
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            total_mentions=5,
+            effective_weight=2.1,
+            last_mentioned_conv_idx=12,
+        )
+        dumped = resp.model_dump(by_alias=True)
+        assert "keywordType" in dumped
+        assert "isNewsRelevant" in dumped
+        assert "totalMentions" in dumped
+        assert "effectiveWeight" in dumped
+        assert "lastMentionedConvIdx" in dumped
+
+
+class TestInterestsListResponse:
+    """Tests for InterestsListResponse schema."""
+
+    @pytest.mark.unit
+    def test_empty_list(self):
+        resp = InterestsListResponse(interests=[])
+        assert resp.interests == []
+
+    @pytest.mark.unit
+    def test_with_items(self):
+        item = InterestResponse(
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            total_mentions=5,
+            effective_weight=2.1,
+            last_mentioned_conv_idx=12,
+        )
+        resp = InterestsListResponse(interests=[item])
+        assert len(resp.interests) == 1
+        assert resp.interests[0].keyword == "tennis"

--- a/apps/api/tests/unit/test_interests_router.py
+++ b/apps/api/tests/unit/test_interests_router.py
@@ -1,0 +1,91 @@
+"""Unit tests for the interests router."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.user import User
+from coyo.repositories.interest import InterestRepository
+
+
+class TestGetInterests:
+    """Tests for GET /api/interests."""
+
+    @pytest.mark.unit
+    async def test_get_interests_empty(self, client: AsyncClient):
+        response = await client.get("/api/interests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["interests"] == []
+
+    @pytest.mark.unit
+    async def test_get_interests_with_data(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        repo = InterestRepository(db_session)
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="tennis",
+            keyword_type="topic",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="kei nishikori",
+            keyword_type="entity",
+            is_news_relevant=True,
+            current_conv_idx=1,
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/interests")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["interests"]) == 2
+
+        # Check camelCase keys
+        interest = data["interests"][0]
+        assert "keywordType" in interest
+        assert "isNewsRelevant" in interest
+        assert "totalMentions" in interest
+        assert "effectiveWeight" in interest
+        assert "lastMentionedConvIdx" in interest
+
+    @pytest.mark.unit
+    async def test_get_interests_sorted_by_weight(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        repo = InterestRepository(db_session)
+        # tennis mentioned 3 times
+        for i in range(1, 4):
+            await repo.upsert_interest(
+                user_id=test_user.id,
+                keyword="tennis",
+                keyword_type="topic",
+                is_news_relevant=True,
+                current_conv_idx=i,
+            )
+        # cooking mentioned 1 time
+        await repo.upsert_interest(
+            user_id=test_user.id,
+            keyword="cooking",
+            keyword_type="topic",
+            is_news_relevant=False,
+            current_conv_idx=1,
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/interests")
+        data = response.json()
+        assert data["interests"][0]["keyword"] == "tennis"
+        assert (
+            data["interests"][0]["effectiveWeight"]
+            > data["interests"][1]["effectiveWeight"]
+        )

--- a/apps/mobile/e2e/app-launch.yaml
+++ b/apps/mobile/e2e/app-launch.yaml
@@ -27,7 +27,13 @@ appId: to.coyo.app
 # Verify the TOPICS section label is visible
 - assertVisible: "TOPICS"
 
-# Verify at least one topic card is present
+# Verify at least one topic card is present (scroll if suggestions push it below the fold)
+# Scroll down to reveal topic cards (avoid sign-out button at bottom)
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
+
 - assertVisible:
     id: "topic-sports"
 

--- a/apps/mobile/e2e/auth-sign-in.yaml
+++ b/apps/mobile/e2e/auth-sign-in.yaml
@@ -45,6 +45,13 @@ appId: to.coyo.app
 - assertVisible:
     id: "home-greeting"
 - assertVisible: "TOPICS"
+# Scroll to verify topic cards exist (suggestions may push them below the fold)
+# Scroll down to reveal topic cards (avoid sign-out button at bottom)
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
+
 - assertVisible:
     id: "topic-sports"
 

--- a/apps/mobile/e2e/feedback-return-home.yaml
+++ b/apps/mobile/e2e/feedback-return-home.yaml
@@ -32,7 +32,21 @@ appId: to.coyo.app
       id: "home-greeting"
     timeout: 30000
 
+# Scroll to the Sports topic card (may be below the fold when suggestions are shown)
+# Scroll down within the content area to reveal topic cards
+# (suggestions may push fixed topics below the fold)
+# Use swipe in the upper half of the screen to avoid hitting the sign-out button at the bottom
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
+
 # Start a conversation on the Sports topic via testID
+- extendedWaitUntil:
+    visible:
+      id: "topic-sports"
+    timeout: 5000
+
 - tapOn:
     id: "topic-sports"
 
@@ -106,6 +120,13 @@ appId: to.coyo.app
 
 # Wait for navigation back to Home
 - waitForAnimationToEnd
+
+# Scroll up to reveal the greeting (page may be scrolled down from earlier)
+- swipe:
+    start: "50%, 30%"
+    end: "50%, 70%"
+    duration: 500
+
 - extendedWaitUntil:
     visible:
       id: "home-greeting"

--- a/apps/mobile/e2e/home-topic-cards.yaml
+++ b/apps/mobile/e2e/home-topic-cards.yaml
@@ -19,8 +19,15 @@ appId: to.coyo.app
 # On Android emulators, the Expo dev client cold start can be slow.
 - extendedWaitUntil:
     visible:
-      id: "topic-sports"
+      id: "home-greeting"
     timeout: 30000
+
+# Scroll to topic cards (suggestions may push them below the fold)
+# Scroll down to reveal topic cards (avoid sign-out button at bottom)
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
 
 # Verify all 5 topic cards are visible via testID
 - assertVisible:

--- a/apps/mobile/e2e/start-conversation.yaml
+++ b/apps/mobile/e2e/start-conversation.yaml
@@ -23,6 +23,18 @@ appId: to.coyo.app
 - assertVisible:
     id: "home-greeting"
 
+# Scroll to the Sports topic card (may be below the fold when suggestions are shown)
+# Scroll down to reveal topic cards (avoid sign-out button at bottom)
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
+
+- extendedWaitUntil:
+    visible:
+      id: "topic-sports"
+    timeout: 5000
+
 # Tap the Sports topic card using its testID
 - tapOn:
     id: "topic-sports"

--- a/apps/mobile/e2e/voice-conversation.yaml
+++ b/apps/mobile/e2e/voice-conversation.yaml
@@ -27,8 +27,20 @@ appId: to.coyo.app
 
 - extendedWaitUntil:
     visible:
-      id: "topic-sports"
+      id: "home-greeting"
     timeout: 30000
+
+# Scroll to the Sports topic card (may be below the fold when suggestions are shown)
+# Scroll down to reveal topic cards (avoid sign-out button at bottom)
+- swipe:
+    start: "50%, 60%"
+    end: "50%, 30%"
+    duration: 500
+
+- extendedWaitUntil:
+    visible:
+      id: "topic-sports"
+    timeout: 5000
 
 - tapOn:
     id: "topic-sports"
@@ -179,7 +191,7 @@ appId: to.coyo.app
 
 - extendedWaitUntil:
     visible:
-      id: "topic-sports"
+      id: "home-greeting"
     timeout: 5000
 
 - takeScreenshot: "voice-06-returned-home"

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -222,7 +222,7 @@ export function HomeScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} testID="home-scroll-view">
         {/* Header area */}
         <View style={styles.header}>
           <View style={styles.headerRow}>

--- a/apps/mobile/src/types/generated/api.ts
+++ b/apps/mobile/src/types/generated/api.ts
@@ -245,6 +245,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/interests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Interests
+         * @description Get top interests for the current user, ordered by effective weight.
+         */
+        get: operations["get_interests_api_interests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/topics/suggestions": {
         parameters: {
             query?: never;
@@ -499,6 +519,35 @@ export interface components {
             page: number;
             /** Perpage */
             perPage: number;
+        };
+        /**
+         * InterestResponse
+         * @description A single user interest with its computed weight.
+         */
+        InterestResponse: {
+            /** Keyword */
+            keyword: string;
+            /**
+             * Keywordtype
+             * @enum {string}
+             */
+            keywordType: "topic" | "entity";
+            /** Isnewsrelevant */
+            isNewsRelevant: boolean;
+            /** Totalmentions */
+            totalMentions: number;
+            /** Effectiveweight */
+            effectiveWeight: number;
+            /** Lastmentionedconvidx */
+            lastMentionedConvIdx: number;
+        };
+        /**
+         * InterestsListResponse
+         * @description List of user interests ordered by effective weight.
+         */
+        InterestsListResponse: {
+            /** Interests */
+            interests: components["schemas"]["InterestResponse"][];
         };
         /**
          * SessionResponse
@@ -1012,6 +1061,39 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_interests_api_interests_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InterestsListResponse"];
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Summary

- Extract user interest keywords (topics + entities) from conversation transcripts via LLM, persisted with a 2-layer weight model (long-term logarithmic + short-term exponential decay)
- Add `GET /api/interests` endpoint for debugging and Pipeline B integration
- Fix E2E tests broken by topic suggestions pushing fixed topic cards below the fold

## Changes

### Backend (new)
| File | Purpose |
|---|---|
| `alembic/versions/0007_add_user_interests.py` | Migration: `user_interests` table, `users.conversation_count`, `conversations.interests_extracted` |
| `models/user_interest.py` | UserInterest ORM model |
| `repositories/interest.py` | Upsert with 2-layer weight model, atomic IntegrityError handling |
| `services/interest_extraction.py` | LLM extraction + background runner via `asyncio.create_task` |
| `schemas/interest.py` | API response schemas with `Literal["topic", "entity"]` |
| `routers/interests.py` | `GET /api/interests` with limit parameter (default 50, max 200) |

### Backend (modified)
| File | Change |
|---|---|
| `config.py` | Add `llm_interest_model = "gpt-5.4-nano"` |
| `services/conversation.py` | Fire background extraction on `end_conversation()` with strong task reference |
| `services/llm/openai_client.py` | `max_tokens` → `max_completion_tokens` (GPT-5.x compatibility) |
| `models/user.py` | Add `conversation_count` column |
| `models/conversation.py` | Add `interests_extracted` column |

### E2E fixes
| File | Change |
|---|---|
| 6 E2E flows | Add swipe-based scroll before tapping `topic-sports` (suggestions push it below the fold; `scrollUntilVisible` triggered sign-out button) |
| `HomeScreen.tsx` | Add `testID="home-scroll-view"` to ScrollView |

### 2-Layer Weight Model
```
effective_weight = long_term + short_term
long_term  = 0.5 × log(1 + total_mentions)
short_term = stored × 0.85 ^ gap
```

## Test plan

- [x] 37 unit tests (repository, service, schema, router) — all passing
- [x] 521 total tests — no regressions
- [x] Integration test against real PostgreSQL + real LLM (gpt-5.4-nano)
- [x] Idempotency verified (re-extraction skipped)
- [x] 2-layer model verified (repeated keywords increase weight)
- [x] `is_news_relevant` prompt accuracy verified (tennis=true, cooking=false)
- [x] E2E `feedback-return-home.yaml` PASS on iOS (conversation lifecycle + background extraction)
- [x] OpenAPI types regenerated, TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)