### PR TITLE
chore: add Claude Code hooks for auto-formatting, linting, and type checking

### DIFF
--- a/.claude/hooks/post-edit-python-format.js
+++ b/.claude/hooks/post-edit-python-format.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: Auto-format Python files with black after edits
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use. If the edited file is a .py file,
+ * formats it with black. Fails silently if black isn't installed.
+ */
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.py$/.test(filePath)) {
+      try {
+        execFileSync("black", ["--quiet", filePath], {
+          cwd: path.dirname(path.resolve(filePath)),
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 15000,
+        });
+      } catch {
+        // black not installed, file missing, or failed — non-blocking
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/post-edit-python-lint.js
+++ b/.claude/hooks/post-edit-python-lint.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: Lint Python files with ruff after edits
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use on Python files. Applies auto-fixes with
+ * ruff check --fix, then reports any remaining errors for the edited file.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.py$/.test(filePath)) {
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) {
+        process.stdout.write(data);
+        process.exit(0);
+      }
+
+      try {
+        // Auto-fix what ruff can fix
+        execFileSync("ruff", ["check", "--fix", "--quiet", resolvedPath], {
+          cwd: path.dirname(resolvedPath),
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 15000,
+        });
+      } catch {
+        // --fix exits non-zero if unfixable errors remain — that's expected
+      }
+
+      try {
+        // Report remaining errors
+        execFileSync("ruff", ["check", "--no-fix", resolvedPath], {
+          cwd: path.dirname(resolvedPath),
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 15000,
+        });
+      } catch (err) {
+        const output = (err.stdout || "") + (err.stderr || "");
+        const relPath = path.relative(
+          path.dirname(resolvedPath),
+          resolvedPath,
+        );
+        const candidates = new Set([filePath, resolvedPath, relPath]);
+        const relevantLines = output
+          .split("\n")
+          .filter((line) => {
+            for (const candidate of candidates) {
+              if (line.includes(candidate)) return true;
+            }
+            return false;
+          })
+          .slice(0, 10);
+
+        if (relevantLines.length > 0) {
+          console.error(
+            "[Hook] ruff errors in " + path.basename(filePath) + ":",
+          );
+          relevantLines.forEach((line) => console.error(line));
+        }
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/post-edit-python-typecheck.js
+++ b/.claude/hooks/post-edit-python-typecheck.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: mypy type check after editing .py files
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use on Python files. Walks up from the file's
+ * directory to find the nearest pyproject.toml, setup.cfg, or mypy.ini,
+ * then runs mypy and reports only errors related to the edited file.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+const MYPY_CONFIG_FILES = ["mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg"];
+
+function findProjectRoot(startDir) {
+  let dir = startDir;
+  const root = path.parse(dir).root;
+  let depth = 0;
+
+  while (dir !== root && depth < 20) {
+    for (const configFile of MYPY_CONFIG_FILES) {
+      if (fs.existsSync(path.join(dir, configFile))) {
+        return dir;
+      }
+    }
+    dir = path.dirname(dir);
+    depth++;
+  }
+
+  return null;
+}
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.py$/.test(filePath)) {
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) {
+        process.stdout.write(data);
+        process.exit(0);
+      }
+
+      const projectRoot = findProjectRoot(path.dirname(resolvedPath));
+      const cwd = projectRoot || path.dirname(resolvedPath);
+
+      try {
+        execFileSync(
+          "mypy",
+          ["--no-error-summary", "--no-pretty", resolvedPath],
+          {
+            cwd,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 30000,
+          },
+        );
+      } catch (err) {
+        // mypy exits non-zero when there are errors
+        const output = (err.stdout || "") + (err.stderr || "");
+        const relPath = path.relative(cwd, resolvedPath);
+        const candidates = new Set([filePath, resolvedPath, relPath]);
+        const relevantLines = output
+          .split("\n")
+          .filter((line) => {
+            for (const candidate of candidates) {
+              if (line.includes(candidate)) return true;
+            }
+            return false;
+          })
+          .slice(0, 10);
+
+        if (relevantLines.length > 0) {
+          console.error(
+            "[Hook] mypy errors in " + path.basename(filePath) + ":",
+          );
+          relevantLines.forEach((line) => console.error(line));
+        }
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/post-edit-typescript-format.js
+++ b/.claude/hooks/post-edit-typescript-format.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: Auto-format JS/TS files with Prettier after edits
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use. If the edited file is a JS/TS file,
+ * formats it with Prettier. Fails silently if Prettier isn't installed.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.(ts|tsx|js|jsx)$/.test(filePath)) {
+      try {
+        // Use npx.cmd on Windows to avoid shell: true which enables command injection
+        const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+        execFileSync(npxBin, ['prettier', '--write', filePath], {
+          cwd: path.dirname(path.resolve(filePath)),
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 15000
+        });
+      } catch {
+        // Prettier not installed, file missing, or failed — non-blocking
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/post-edit-typescript-lint.js
+++ b/.claude/hooks/post-edit-typescript-lint.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: Lint JS/TS files with ESLint after edits
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use on JS/TS files. Walks up from the file's
+ * directory to find the nearest ESLint config, applies auto-fixes,
+ * then reports any remaining errors for the edited file.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+const ESLINT_CONFIG_FILES = [
+  "eslint.config.js",
+  "eslint.config.mjs",
+  "eslint.config.cjs",
+  "eslint.config.ts",
+  "eslint.config.mts",
+  "eslint.config.cts",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  ".eslintrc.json",
+  ".eslintrc.yml",
+  ".eslintrc.yaml",
+  ".eslintrc",
+];
+
+function findProjectRoot(startDir) {
+  let dir = startDir;
+  const root = path.parse(dir).root;
+  let depth = 0;
+
+  while (dir !== root && depth < 20) {
+    for (const configFile of ESLINT_CONFIG_FILES) {
+      if (fs.existsSync(path.join(dir, configFile))) {
+        return dir;
+      }
+    }
+    dir = path.dirname(dir);
+    depth++;
+  }
+
+  return null;
+}
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.(ts|tsx|js|jsx)$/.test(filePath)) {
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) {
+        process.stdout.write(data);
+        process.exit(0);
+      }
+
+      const projectRoot = findProjectRoot(path.dirname(resolvedPath));
+      if (!projectRoot) {
+        // No ESLint config found — skip
+        process.stdout.write(data);
+        process.exit(0);
+      }
+
+      const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
+
+      // Auto-fix then report remaining errors
+      try {
+        execFileSync(npxBin, ["eslint", "--fix", "--quiet", resolvedPath], {
+          cwd: projectRoot,
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 30000,
+        });
+      } catch {
+        // --fix exits non-zero if unfixable errors remain — that's expected
+      }
+
+      try {
+        execFileSync(
+          npxBin,
+          ["eslint", "--no-fix", "--format", "unix", resolvedPath],
+          {
+            cwd: projectRoot,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 30000,
+          },
+        );
+      } catch (err) {
+        const output = (err.stdout || "") + (err.stderr || "");
+        const relPath = path.relative(projectRoot, resolvedPath);
+        const candidates = new Set([filePath, resolvedPath, relPath]);
+        const relevantLines = output
+          .split("\n")
+          .filter((line) => {
+            for (const candidate of candidates) {
+              if (line.includes(candidate)) return true;
+            }
+            return false;
+          })
+          .slice(0, 10);
+
+        if (relevantLines.length > 0) {
+          console.error(
+            "[Hook] ESLint errors in " + path.basename(filePath) + ":",
+          );
+          relevantLines.forEach((line) => console.error(line));
+        }
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/post-edit-typescript-typecheck.js
+++ b/.claude/hooks/post-edit-typescript-typecheck.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: TypeScript check after editing .ts/.tsx files
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs after Edit tool use on TypeScript files. Walks up from the file's
+ * directory to find the nearest tsconfig.json, then runs tsc --noEmit
+ * and reports only errors related to the edited file.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const MAX_STDIN = 1024 * 1024; // 1MB limit
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && /\.(ts|tsx)$/.test(filePath)) {
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) {
+        process.stdout.write(data);
+        process.exit(0);
+      }
+      // Find nearest tsconfig.json by walking up (max 20 levels to prevent infinite loop)
+      let dir = path.dirname(resolvedPath);
+      const root = path.parse(dir).root;
+      let depth = 0;
+
+      while (dir !== root && depth < 20) {
+        if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+          break;
+        }
+        dir = path.dirname(dir);
+        depth++;
+      }
+
+      if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+        try {
+          // Use npx.cmd on Windows to avoid shell: true which enables command injection
+          const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
+          execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
+            cwd: dir,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 30000,
+          });
+        } catch (err) {
+          // tsc exits non-zero when there are errors — filter to edited file
+          const output = (err.stdout || "") + (err.stderr || "");
+          // Compute paths that uniquely identify the edited file.
+          // tsc output uses paths relative to its cwd (the tsconfig dir),
+          // so check for the relative path, absolute path, and original path.
+          // Avoid bare basename matching — it causes false positives when
+          // multiple files share the same name (e.g., src/utils.ts vs tests/utils.ts).
+          const relPath = path.relative(dir, resolvedPath);
+          const candidates = new Set([filePath, resolvedPath, relPath]);
+          const relevantLines = output
+            .split("\n")
+            .filter((line) => {
+              for (const candidate of candidates) {
+                if (line.includes(candidate)) return true;
+              }
+              return false;
+            })
+            .slice(0, 10);
+
+          if (relevantLines.length > 0) {
+            console.error(
+              "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
+            );
+            relevantLines.forEach((line) => console.error(line));
+          }
+        }
+      }
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/hooks/pre-commit-test-reminder.js
+++ b/.claude/hooks/pre-commit-test-reminder.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Hook: Remind Claude to run tests before committing
+ *
+ * Fires when a Bash tool call contains "git commit". Outputs a
+ * reminder on stderr (visible to Claude as hook feedback) but
+ * does NOT block the commit — the reminder is a soft gate.
+ */
+
+const MAX_STDIN = 1024 * 1024;
+let data = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  if (data.length < MAX_STDIN) {
+    data += chunk;
+  }
+});
+
+process.stdin.on("end", () => {
+  try {
+    const input = JSON.parse(data);
+    const command = input.tool_input?.command || "";
+
+    if (/git\s+commit/.test(command)) {
+      console.error(
+        [
+          "[Hook] ⚠️ Pre-Commit Checklist — have you completed ALL of these?",
+          "  1. Tests written for new/changed code",
+          "  2. Tests passing (pytest / npx jest)",
+          "  3. Build passing (tsc --noEmit / expo export)",
+          "  4. Coverage ≥ 80% for new/changed code",
+          "If NOT, abort this commit and run tests first.",
+          "If the user explicitly asked to skip testing, proceed.",
+        ].join("\n"),
+      );
+    }
+  } catch {
+    // Invalid input — pass through
+  }
+
+  process.stdout.write(data);
+  process.exit(0);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,71 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"git\\\\s+commit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/pre-commit-test-reminder.js\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-typescript-format.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-typescript-lint.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-typescript-typecheck.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.py$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-python-format.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.py$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-python-lint.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.py$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \".claude/hooks/post-edit-python-typecheck.js\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add PostToolUse hooks that automatically run formatters, linters, and type checkers after Claude Code edits files (Prettier/ESLint/tsc for TS/JS, black/ruff/mypy for Python)
- Add PreToolUse hook that reminds to run tests before committing
- Add `.claude/settings.json` with hook matcher configuration

## Test plan
- [ ] Edit a `.ts` file with Claude Code and verify Prettier, ESLint, and tsc hooks fire
- [ ] Edit a `.py` file with Claude Code and verify black, ruff, and mypy hooks fire
- [ ] Run `git commit` via Claude Code and verify pre-commit test reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)