### PR TITLE
feat: add personal topic generation pipeline (Pipeline B)

### DIFF
--- a/apps/api/src/coyo/repositories/topic_suggestion.py
+++ b/apps/api/src/coyo/repositories/topic_suggestion.py
@@ -108,6 +108,28 @@ class TopicSuggestionRepository:
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none() is not None
 
+    async def get_personal_suggestions(self, target_date: date) -> list[TopicSuggestion]:
+        """Get personal pool suggestions for a date (idempotency check)."""
+        stmt = (
+            select(TopicSuggestion)
+            .where(
+                TopicSuggestion.generated_date == target_date,
+                TopicSuggestion.pool_type == "personal",
+            )
+            .order_by(TopicSuggestion.created_at)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_active_users_with_conv_count(self) -> list[tuple[uuid.UUID, int]]:
+        """Get (user_id, conversation_count) for all active users."""
+        # Deferred import to avoid circular dependency: topic_suggestion -> user -> ...
+        from coyo.models.user import User
+
+        stmt = select(User.id, User.conversation_count)
+        result = await self._session.execute(stmt)
+        return list(result.tuples().all())
+
     async def get_active_user_ids(self) -> list[uuid.UUID]:
         """Get IDs of all users."""
         # Deferred import to avoid circular dependency: topic_suggestion -> user -> ...

--- a/apps/api/src/coyo/routers/topics.py
+++ b/apps/api/src/coyo/routers/topics.py
@@ -3,6 +3,7 @@
 import hmac
 from datetime import date
 
+import structlog
 from fastapi import APIRouter, Depends, Header, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +15,8 @@ from coyo.rate_limit import DEFAULT_RATE_LIMIT, EXPENSIVE_RATE_LIMIT, limiter
 from coyo.repositories.topic_suggestion import TopicSuggestionRepository
 from coyo.schemas.topic import TopicSuggestionResponse, TopicSuggestionsListResponse
 from coyo.services.topic_generation import TopicGenerationService
+
+logger = structlog.get_logger()
 
 router = APIRouter(prefix="/api/topics", tags=["topics"])
 
@@ -82,4 +85,14 @@ async def generate_topics(
     topic_count = await service.generate_common_topics()
     user_count = await service.assign_to_users()
 
-    return {"topics_generated": topic_count, "users_assigned": user_count}
+    personal_count = 0
+    try:
+        personal_count = await service.generate_personal_topics()
+    except Exception:
+        logger.exception("personal_topic_generation_failed")
+
+    return {
+        "topics_generated": topic_count,
+        "users_assigned": user_count,
+        "personal_topics_generated": personal_count,
+    }

--- a/apps/api/src/coyo/services/topic_generation.py
+++ b/apps/api/src/coyo/services/topic_generation.py
@@ -1,18 +1,26 @@
 """Service for generating topic suggestions via LLM + web search."""
 
+from __future__ import annotations
+
 import re
 from datetime import date
+from typing import TYPE_CHECKING
 
 import structlog
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.config import get_settings
+from coyo.repositories.interest import InterestRepository
 from coyo.repositories.topic_suggestion import TopicSuggestionRepository
 from coyo.services.llm.base import ChatMessage, ChatOptions, TextChunk
 from coyo.services.llm.openai_client import OpenAIClient
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger()
 
@@ -44,9 +52,32 @@ Return your response as valid JSON with this structure:
 }}
 """
 
+_PERSONAL_SEARCH_PROMPT_TEMPLATE = """\
+Today is {today}. Search for the latest news about "{keyword}" \
+from TODAY or the past few days that would make a great English \
+conversation starter for Japanese learners.
+
+For the topic, provide:
+1. A short catchy title (in English, max 10 words)
+2. A brief summary (in English, 2 sentences)
+3. Detailed article content for conversation context \
+(in English, 500-800 characters). Include key facts, recent \
+developments, and interesting angles for discussion.
+
+Return your response as valid JSON:
+{{
+  "title": "...",
+  "summary": "...",
+  "article_content": "..."
+}}
+"""
+
 _MAX_TOPICS = 3
+_PERSONAL_MAX_KEYWORDS = 7
 
 _CODE_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+_SAFE_KEYWORD_RE = re.compile(r"^[\w\s\-'/&.,()]+$", re.UNICODE)
+_MAX_KEYWORD_LENGTH = 100
 
 
 class TopicItem(BaseModel):
@@ -64,10 +95,28 @@ class TopicSearchResult(BaseModel):
     topics: list[TopicItem]
 
 
+class PersonalTopicItem(BaseModel):
+    """A single personal topic parsed from the LLM response."""
+
+    title: str
+    summary: str
+    article_content: str
+
+
 def _extract_json(text: str) -> str:
     """Strip markdown code fences if present."""
     match = _CODE_FENCE_RE.search(text)
     return match.group(1).strip() if match else text.strip()
+
+
+def _sanitize_keyword(keyword: str) -> str | None:
+    """Return the keyword if safe for LLM prompt interpolation, else None."""
+    keyword = keyword.strip()
+    if not keyword or len(keyword) > _MAX_KEYWORD_LENGTH:
+        return None
+    if not _SAFE_KEYWORD_RE.match(keyword):
+        return None
+    return keyword
 
 
 class TopicGenerationService:
@@ -76,6 +125,7 @@ class TopicGenerationService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
         self._repo = TopicSuggestionRepository(session)
+        self._interest_repo = InterestRepository(session)
         settings = get_settings()
         self._llm = OpenAIClient(model=settings.llm_topic_model)
 
@@ -174,3 +224,177 @@ class TopicGenerationService:
             )
             # Fallback: use structured output
             return await self._llm.structured(messages, TopicSearchResult, options=options)
+
+    async def generate_personal_topics(self) -> int:
+        """Generate personal topics for all users based on their interests.
+
+        Returns the number of personal topics generated.
+        """
+        today = date.today()
+
+        # Idempotency: skip if personal topics already exist for today
+        existing = await self._repo.get_personal_suggestions(today)
+        if existing:
+            logger.info(
+                "personal_topics_already_generated",
+                date=str(today),
+                count=len(existing),
+            )
+            return len(existing)
+
+        keyword_to_users = await self._collect_personal_keywords(today)
+        if not keyword_to_users:
+            return 0
+
+        # Fetch, store, and assign each keyword's topic
+        logger.info(
+            "personal_topic_keywords_to_process",
+            count=len(keyword_to_users),
+        )
+        count = 0
+        for keyword, user_list in keyword_to_users.items():
+            if await self._store_and_assign_personal_topic(
+                keyword, user_list, today
+            ):
+                count += 1
+
+        await self._session.commit()
+        logger.info("personal_topic_generation_done", count=count)
+        return count
+
+    async def _collect_personal_keywords(
+        self, today: date
+    ) -> dict[str, list[tuple[uuid.UUID, float]]]:
+        """Collect and deduplicate personal keywords across all users."""
+        users = await self._repo.get_active_users_with_conv_count()
+        if not users:
+            return {}
+
+        # Step 1: Collect top keywords per user
+        user_keywords: dict[uuid.UUID, list[tuple[str, float]]] = {}
+        for user_id, conv_count in users:
+            interests = await self._interest_repo.get_top_interests(
+                user_id,
+                conv_count,
+                keyword_type="topic",
+                is_news_relevant=True,
+                limit=_PERSONAL_MAX_KEYWORDS,
+            )
+            if interests:
+                user_keywords[user_id] = [
+                    (i.keyword, i.effective_weight) for i in interests
+                ]
+
+        if not user_keywords:
+            logger.info("no_user_interests_found")
+            return {}
+
+        # Step 2: Deduplicate against common pool
+        common_suggestions = await self._repo.get_common_suggestions(today)
+        common_keywords = {s.source_keyword.lower() for s in common_suggestions}
+
+        # Step 3: Pool unique keywords across users
+        keyword_to_users: dict[str, list[tuple[uuid.UUID, float]]] = {}
+        for user_id, kw_list in user_keywords.items():
+            for keyword, weight in kw_list:
+                if keyword.lower() not in common_keywords:
+                    keyword_to_users.setdefault(keyword, []).append(
+                        (user_id, weight)
+                    )
+
+        if not keyword_to_users:
+            logger.info("all_personal_keywords_overlap_common")
+
+        return keyword_to_users
+
+    async def _store_and_assign_personal_topic(
+        self,
+        keyword: str,
+        user_list: list[tuple[uuid.UUID, float]],
+        today: date,
+    ) -> bool:
+        """Fetch, store, and assign a personal topic for a keyword.
+
+        Returns True if the topic was successfully created.
+        """
+        topic = await self._fetch_personal_topic(keyword, today)
+        if topic is None:
+            return False
+
+        try:
+            async with self._session.begin_nested():
+                suggestion = await self._repo.create_suggestion(
+                    title=topic.title,
+                    summary=topic.summary,
+                    source_keyword=keyword,
+                    article_content=topic.article_content,
+                    article_url=None,
+                    pool_type="personal",
+                    generated_date=today,
+                )
+        except IntegrityError:
+            logger.exception(
+                "personal_topic_save_error", keyword=keyword[:50]
+            )
+            return False
+
+        for user_id, weight in user_list:
+            try:
+                async with self._session.begin_nested():
+                    await self._repo.create_user_suggestion(
+                        user_id=user_id,
+                        topic_suggestion_id=suggestion.id,
+                        relevance_score=weight,
+                    )
+            except IntegrityError:
+                logger.debug(
+                    "personal_user_suggestion_duplicate",
+                    user_id=str(user_id),
+                    suggestion_id=str(suggestion.id),
+                )
+
+        return True
+
+    async def _fetch_personal_topic(
+        self, keyword: str, today: date
+    ) -> PersonalTopicItem | None:
+        """Fetch a single personal topic via LLM + web search."""
+        sanitized = _sanitize_keyword(keyword)
+        if sanitized is None:
+            logger.warning(
+                "keyword_sanitization_rejected", keyword=keyword[:50]
+            )
+            return None
+
+        prompt = _PERSONAL_SEARCH_PROMPT_TEMPLATE.format(
+            today=today.isoformat(),
+            keyword=sanitized,
+        )
+        messages = [ChatMessage(role="user", content=prompt)]
+        options = ChatOptions(temperature=0.7, max_tokens=1500)
+
+        chunks: list[str] = []
+        async for event in self._llm.chat_with_tools(messages, options=options):
+            if isinstance(event, TextChunk):
+                chunks.append(event.text)
+        full_text = "".join(chunks)
+
+        try:
+            cleaned = _extract_json(full_text)
+            return PersonalTopicItem.model_validate_json(cleaned)
+        except (PydanticValidationError, ValueError):
+            logger.warning(
+                "personal_topic_parse_error",
+                keyword=keyword[:50],
+                raw_text_length=len(full_text),
+            )
+            try:
+                return await self._llm.structured(
+                    messages, PersonalTopicItem, options=options
+                )
+            except Exception:
+                logger.exception(
+                    "personal_topic_structured_fallback_failed",
+                    keyword=keyword[:50],
+                )
+                return None

--- a/apps/api/tests/unit/test_personal_topic_generation.py
+++ b/apps/api/tests/unit/test_personal_topic_generation.py
@@ -1,0 +1,343 @@
+"""Unit tests for personal topic generation in TopicGenerationService."""
+
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.repositories.interest import InterestWithWeight
+from coyo.services.llm.base import TextChunk
+from coyo.services.topic_generation import PersonalTopicItem, TopicGenerationService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_suggestion_mock(suggestion_id: uuid.UUID | None = None, **kwargs):
+    """Create a mock TopicSuggestion object."""
+    mock = MagicMock()
+    mock.id = suggestion_id or uuid.uuid4()
+    mock.title = kwargs.get("title", "Test Topic")
+    mock.summary = kwargs.get("summary", "Test Summary")
+    mock.source_keyword = kwargs.get("source_keyword", "test")
+    mock.article_content = kwargs.get("article_content", "Test content")
+    mock.pool_type = kwargs.get("pool_type", "personal")
+    return mock
+
+
+def _make_interest(keyword: str, weight: float = 1.0) -> InterestWithWeight:
+    """Create an InterestWithWeight for testing."""
+    return InterestWithWeight(
+        keyword=keyword,
+        keyword_type="topic",
+        is_news_relevant=True,
+        total_mentions=3,
+        effective_weight=weight,
+        last_mentioned_conv_idx=5,
+    )
+
+
+def _make_personal_topic_json(
+    title: str = "Test Title",
+    summary: str = "Test Summary",
+    article_content: str = "Test article content here",
+) -> str:
+    """Build a valid JSON string for PersonalTopicItem."""
+    return (
+        f'{{"title":"{title}","summary":"{summary}",'
+        f'"article_content":"{article_content}"}}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestGeneratePersonalTopics
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePersonalTopics:
+    """Tests for TopicGenerationService.generate_personal_topics."""
+
+    @pytest.fixture
+    def mock_repo(self):
+        """Create a mock TopicSuggestionRepository."""
+        repo = AsyncMock()
+        repo.get_personal_suggestions = AsyncMock(return_value=[])
+        repo.get_common_suggestions = AsyncMock(return_value=[])
+        repo.create_suggestion = AsyncMock(
+            side_effect=lambda **kwargs: _make_suggestion_mock(**kwargs)
+        )
+        repo.create_user_suggestion = AsyncMock()
+        return repo
+
+    @pytest.fixture
+    def mock_interest_repo(self):
+        """Create a mock InterestRepository."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_llm(self):
+        """Create a mock OpenAIClient that returns valid personal topic JSON."""
+        mock = MagicMock()
+
+        async def mock_chat_with_tools(messages, options=None):
+            yield TextChunk(text=_make_personal_topic_json())
+
+        mock.chat_with_tools = mock_chat_with_tools
+        return mock
+
+    @pytest.fixture
+    def service(
+        self, db_session: AsyncSession, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """Create a TopicGenerationService with mocked dependencies."""
+        svc = TopicGenerationService.__new__(TopicGenerationService)
+        svc._session = db_session
+        svc._repo = mock_repo
+        svc._interest_repo = mock_interest_repo
+        svc._llm = mock_llm
+        return svc
+
+    @pytest.mark.unit
+    async def test_generate_personal_topics_happy_path(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """2 users with interests: LLM called per unique keyword, suggestions created."""
+        user1 = uuid.uuid4()
+        user2 = uuid.uuid4()
+
+        mock_repo.get_active_users_with_conv_count = AsyncMock(
+            return_value=[(user1, 10), (user2, 5)]
+        )
+
+        # User1 has "NBA", User2 has "AI"
+        async def get_top_interests(user_id, conv_count, **kwargs):
+            if user_id == user1:
+                return [_make_interest("NBA", 2.0)]
+            return [_make_interest("AI", 1.5)]
+
+        mock_interest_repo.get_top_interests = AsyncMock(
+            side_effect=get_top_interests
+        )
+
+        count = await service.generate_personal_topics()
+
+        assert count == 2
+        # create_suggestion called once per unique keyword
+        assert mock_repo.create_suggestion.call_count == 2
+        # Verify pool_type is "personal"
+        for call in mock_repo.create_suggestion.call_args_list:
+            assert call.kwargs["pool_type"] == "personal"
+        # create_user_suggestion called once per user-keyword pair
+        assert mock_repo.create_user_suggestion.call_count == 2
+
+    @pytest.mark.unit
+    async def test_generate_personal_topics_idempotent(
+        self, service, mock_repo, mock_interest_repo
+    ):
+        """When personal topics already exist for today, skip and return existing count."""
+        existing = [_make_suggestion_mock() for _ in range(3)]
+        mock_repo.get_personal_suggestions = AsyncMock(return_value=existing)
+
+        count = await service.generate_personal_topics()
+
+        assert count == 3
+        mock_repo.create_suggestion.assert_not_called()
+        mock_interest_repo.get_top_interests.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_deduplication_against_common(
+        self, service, mock_repo, mock_interest_repo
+    ):
+        """If a user's keyword matches a common topic's source_keyword, exclude it."""
+        user1 = uuid.uuid4()
+        mock_repo.get_active_users_with_conv_count = AsyncMock(
+            return_value=[(user1, 10)]
+        )
+
+        # User has "NBA" and "AI"
+        mock_interest_repo.get_top_interests = AsyncMock(
+            return_value=[_make_interest("NBA", 2.0), _make_interest("AI", 1.5)]
+        )
+
+        # "nba" is already a common topic (case-insensitive match)
+        common = _make_suggestion_mock(source_keyword="NBA")
+        mock_repo.get_common_suggestions = AsyncMock(return_value=[common])
+
+        count = await service.generate_personal_topics()
+
+        # Only "AI" should be generated (NBA excluded)
+        assert count == 1
+        assert mock_repo.create_suggestion.call_count == 1
+        assert mock_repo.create_suggestion.call_args.kwargs["source_keyword"] == "AI"
+
+    @pytest.mark.unit
+    async def test_keyword_pooling_across_users(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """When 2 users share the same keyword, 1 web search but 2 user-suggestion links."""
+        user1 = uuid.uuid4()
+        user2 = uuid.uuid4()
+
+        mock_repo.get_active_users_with_conv_count = AsyncMock(
+            return_value=[(user1, 10), (user2, 8)]
+        )
+
+        # Both users have "NBA"
+        mock_interest_repo.get_top_interests = AsyncMock(
+            return_value=[_make_interest("NBA", 2.0)]
+        )
+
+        # Track LLM calls
+        call_count = 0
+
+        async def counting_chat(messages, options=None):
+            nonlocal call_count
+            call_count += 1
+            yield TextChunk(text=_make_personal_topic_json())
+
+        mock_llm.chat_with_tools = counting_chat
+
+        count = await service.generate_personal_topics()
+
+        # 1 keyword = 1 LLM call, 1 suggestion
+        assert call_count == 1
+        assert count == 1
+        assert mock_repo.create_suggestion.call_count == 1
+        # But 2 user-suggestion links (one per user)
+        assert mock_repo.create_user_suggestion.call_count == 2
+
+    @pytest.mark.unit
+    async def test_fetch_personal_topic_returns_none_skips_keyword(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """When LLM returns invalid JSON and fallback also fails, keyword is skipped."""
+        user1 = uuid.uuid4()
+        mock_repo.get_active_users_with_conv_count = AsyncMock(
+            return_value=[(user1, 10)]
+        )
+        mock_interest_repo.get_top_interests = AsyncMock(
+            return_value=[_make_interest("NBA", 2.0)]
+        )
+
+        # LLM returns garbage
+        async def bad_chat(messages, options=None):
+            yield TextChunk(text="not valid json at all")
+
+        mock_llm.chat_with_tools = bad_chat
+        # Structured fallback also fails
+        mock_llm.structured = AsyncMock(side_effect=Exception("structured failed"))
+
+        count = await service.generate_personal_topics()
+
+        assert count == 0
+        mock_repo.create_suggestion.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_users_without_interests_skipped(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """When no users have interests, return 0 with no LLM calls."""
+        user1 = uuid.uuid4()
+        mock_repo.get_active_users_with_conv_count = AsyncMock(
+            return_value=[(user1, 5)]
+        )
+        # No interests returned
+        mock_interest_repo.get_top_interests = AsyncMock(return_value=[])
+
+        call_count = 0
+
+        async def counting_chat(messages, options=None):
+            nonlocal call_count
+            call_count += 1
+            yield TextChunk(text=_make_personal_topic_json())
+
+        mock_llm.chat_with_tools = counting_chat
+
+        count = await service.generate_personal_topics()
+
+        assert count == 0
+        assert call_count == 0
+        mock_repo.create_suggestion.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestFetchPersonalTopic
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPersonalTopic:
+    """Tests for TopicGenerationService._fetch_personal_topic."""
+
+    @pytest.fixture
+    def mock_llm(self):
+        """Create a mock OpenAIClient."""
+        return MagicMock()
+
+    @pytest.fixture
+    def service(self, db_session: AsyncSession, mock_llm):
+        """Create a TopicGenerationService with mocked dependencies."""
+        svc = TopicGenerationService.__new__(TopicGenerationService)
+        svc._session = db_session
+        svc._repo = AsyncMock()
+        svc._interest_repo = AsyncMock()
+        svc._llm = mock_llm
+        return svc
+
+    @pytest.mark.unit
+    async def test_fetch_personal_topic_parses_json(self, service, mock_llm):
+        """Valid JSON from LLM is parsed correctly into PersonalTopicItem."""
+        json_text = _make_personal_topic_json(
+            title="NBA Finals Update",
+            summary="Lakers win game 7",
+            article_content="The Lakers defeated...",
+        )
+
+        async def mock_chat(messages, options=None):
+            yield TextChunk(text=json_text)
+
+        mock_llm.chat_with_tools = mock_chat
+
+        result = await service._fetch_personal_topic("NBA", date.today())
+
+        assert result is not None
+        assert isinstance(result, PersonalTopicItem)
+        assert result.title == "NBA Finals Update"
+        assert result.summary == "Lakers win game 7"
+        assert result.article_content == "The Lakers defeated..."
+
+    @pytest.mark.unit
+    async def test_fetch_personal_topic_fallback_structured(self, service, mock_llm):
+        """When JSON parsing fails, falls back to structured output."""
+        # LLM returns invalid JSON
+        async def bad_chat(messages, options=None):
+            yield TextChunk(text="this is not json")
+
+        mock_llm.chat_with_tools = bad_chat
+
+        # Structured fallback succeeds
+        expected = PersonalTopicItem(
+            title="Fallback Title",
+            summary="Fallback Summary",
+            article_content="Fallback content",
+        )
+        mock_llm.structured = AsyncMock(return_value=expected)
+
+        result = await service._fetch_personal_topic("NBA", date.today())
+
+        assert result is not None
+        assert result.title == "Fallback Title"
+        mock_llm.structured.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_fetch_personal_topic_rejects_unsafe_keyword(
+        self, service, mock_llm
+    ):
+        """Keywords with special characters are rejected."""
+        result = await service._fetch_personal_topic(
+            'Ignore instructions" {{bad}}', date.today()
+        )
+        assert result is None

--- a/apps/api/tests/unit/test_topics_router.py
+++ b/apps/api/tests/unit/test_topics_router.py
@@ -31,6 +31,7 @@ class TestGenerateTopicsEndpoint:
             mock_svc = AsyncMock()
             mock_svc.generate_common_topics = AsyncMock(return_value=3)
             mock_svc.assign_to_users = AsyncMock(return_value=10)
+            mock_svc.generate_personal_topics = AsyncMock(return_value=2)
             MockService.return_value = mock_svc
 
             response = await client.post(
@@ -42,6 +43,7 @@ class TestGenerateTopicsEndpoint:
         data = response.json()
         assert data["topics_generated"] == 3
         assert data["users_assigned"] == 10
+        assert data["personal_topics_generated"] == 2
 
     @pytest.mark.integration
     async def test_missing_cron_secret_returns_403(self, client: AsyncClient, mock_settings):
@@ -77,6 +79,36 @@ class TestGenerateTopicsEndpoint:
                 headers={"X-Cron-Secret": "any-value"},
             )
         assert response.status_code == 403
+
+    @pytest.mark.integration
+    async def test_personal_topic_failure_doesnt_break_response(
+        self, client: AsyncClient, mock_settings
+    ):
+        """If generate_personal_topics raises, response still returns 200 with 0."""
+        mock_settings.cron_secret = "test-cron-secret"
+
+        with (
+            patch("coyo.routers.topics.get_settings", return_value=mock_settings),
+            patch("coyo.routers.topics.TopicGenerationService") as MockService,
+        ):
+            mock_svc = AsyncMock()
+            mock_svc.generate_common_topics = AsyncMock(return_value=3)
+            mock_svc.assign_to_users = AsyncMock(return_value=10)
+            mock_svc.generate_personal_topics = AsyncMock(
+                side_effect=Exception("LLM down")
+            )
+            MockService.return_value = mock_svc
+
+            response = await client.post(
+                "/api/topics/generate",
+                headers={"X-Cron-Secret": "test-cron-secret"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["personal_topics_generated"] == 0
+        assert data["topics_generated"] == 3
+        assert data["users_assigned"] == 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `generate_personal_topics()` to generate personalized topic suggestions based on user interests (Pipeline B)
- Collect top M=7 keywords per user (`keyword_type="topic"`, `is_news_relevant=True`), deduplicate against common pool, pool shared keywords across users for single LLM calls, and assign with `relevance_score = effective_weight`
- Add keyword sanitization to prevent LLM prompt injection
- Wrap personal generation in try/except so failures don't break the existing common topic cron job

## Changed Files

- `repositories/topic_suggestion.py` — `get_personal_suggestions()`, `get_active_users_with_conv_count()`
- `services/topic_generation.py` — `generate_personal_topics()`, `_collect_personal_keywords()`, `_store_and_assign_personal_topic()`, `_fetch_personal_topic()`, `PersonalTopicItem`, `_sanitize_keyword()`
- `routers/topics.py` — Extended cron endpoint with personal topic generation
- `tests/unit/test_personal_topic_generation.py` — 9 new tests (happy path, idempotency, deduplication, pooling, error paths, keyword sanitization)
- `tests/unit/test_topics_router.py` — Updated for `personal_topics_generated` response field

## Test plan

- [x] 531 unit tests pass
- [x] ruff clean
- [x] Manual test: `POST /api/topics/generate` generates personal topics from user interests
- [x] Manual test: `GET /api/topics/suggestions` returns personal topics in the `personal` array
- [x] Manual test: Idempotency — second call does not duplicate topics
- [x] Manual test: Personal topics visible on iOS home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)