### PR TITLE
feat: migrate interest extraction to Cloud Tasks with asyncio fallback

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "sse-starlette>=2.2",
     "firebase-admin>=6.5",
     "slowapi>=0.1.9",
+    "google-cloud-tasks>=2.16",
+    "google-auth>=2.29",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -36,6 +36,12 @@ class Settings(BaseSettings):
     # Cron
     cron_secret: str | None = None
 
+    # Cloud Tasks (None = local development, asyncio fallback)
+    cloud_tasks_project: str | None = None
+    cloud_tasks_location: str | None = None
+    cloud_tasks_queue: str | None = None
+    cloud_run_service_url: str | None = None
+
     # TTS Config
     tts_voice: str = "nova"
     tts_model: str = "tts-1"
@@ -58,6 +64,23 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 30
 
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    @model_validator(mode="after")
+    def validate_cloud_tasks_settings(self) -> Self:
+        """Ensure Cloud Tasks settings are all set or all None."""
+        fields = [
+            self.cloud_tasks_project,
+            self.cloud_tasks_location,
+            self.cloud_tasks_queue,
+            self.cloud_run_service_url,
+        ]
+        non_none = [f for f in fields if f is not None]
+        if non_none and len(non_none) != 4:
+            raise ValueError(
+                "Cloud Tasks settings must be all set or all None. "
+                f"Got {len(non_none)}/4 configured."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_cors_origins(self) -> Self:

--- a/apps/api/src/coyo/dependencies.py
+++ b/apps/api/src/coyo/dependencies.py
@@ -31,6 +31,14 @@ _PROVIDER_MAPPING: dict[str, AuthProvider] = {
 }
 
 
+def _extract_bearer_token(authorization: str) -> str:
+    """Extract token from 'Bearer <token>' header, or raise."""
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise AuthenticationError("Invalid Authorization header format")
+    return parts[1]
+
+
 def map_provider(sign_in_provider: str) -> AuthProvider:
     """Map Firebase sign_in_provider to our auth_provider value."""
     mapped = _PROVIDER_MAPPING.get(sign_in_provider)
@@ -57,11 +65,44 @@ async def get_firebase_token(
     if authorization is None:
         return None
 
-    parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        raise AuthenticationError("Invalid Authorization header format")
+    token = _extract_bearer_token(authorization)
+    return await asyncio.to_thread(verify_firebase_token, token)
 
-    return await asyncio.to_thread(verify_firebase_token, parts[1])
+
+async def verify_cloud_task_token(
+    authorization: Annotated[str | None, Header()] = None,
+) -> None:
+    """Verify OIDC token from Cloud Tasks.
+
+    Skips verification when cloud_run_service_url is not configured (local dev).
+    """
+    from coyo.config import get_settings
+
+    settings = get_settings()
+    if not settings.cloud_run_service_url:
+        return
+
+    if authorization is None:
+        raise AuthenticationError("Missing Authorization header")
+
+    token = _extract_bearer_token(authorization)
+    try:
+        await asyncio.to_thread(
+            _verify_oidc_token, token, settings.cloud_run_service_url
+        )
+    except AuthenticationError:
+        raise
+    except Exception:
+        logger.warning("oidc_verification_failed", exc_info=True)
+        raise AuthenticationError("Invalid OIDC token") from None
+
+
+def _verify_oidc_token(token: str, audience: str) -> None:
+    """Verify Google OIDC token (blocking, run in thread)."""
+    from google.auth.transport.requests import Request
+    from google.oauth2 import id_token
+
+    id_token.verify_oauth2_token(token, Request(), audience)
 
 
 async def get_current_user(

--- a/apps/api/src/coyo/main.py
+++ b/apps/api/src/coyo/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from coyo.middleware import setup_middleware
-from coyo.routers import auth, conversations, history, interests, topics
+from coyo.routers import auth, conversations, history, interests, tasks, topics
 
 _is_prod = os.getenv("ENVIRONMENT") == "production"
 
@@ -46,6 +46,7 @@ app.include_router(auth.router)
 app.include_router(conversations.router)
 app.include_router(history.router)
 app.include_router(interests.router)
+app.include_router(tasks.router)
 app.include_router(topics.router)
 
 

--- a/apps/api/src/coyo/routers/tasks.py
+++ b/apps/api/src/coyo/routers/tasks.py
@@ -1,0 +1,28 @@
+"""Task handler endpoints for Cloud Tasks callbacks."""
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from coyo.dependencies import verify_cloud_task_token
+from coyo.services.interest_extraction import InterestExtractionService
+
+router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+
+class ExtractInterestsRequest(BaseModel):
+    """Request body for interest extraction task."""
+
+    conversation_id: uuid.UUID
+    user_id: uuid.UUID
+
+
+@router.post("/extract-interests", dependencies=[Depends(verify_cloud_task_token)])
+async def extract_interests(body: ExtractInterestsRequest) -> dict[str, str]:
+    """Handle interest extraction task from Cloud Tasks.
+
+    Cloud Tasks retries on 5xx responses, so errors are propagated.
+    """
+    await InterestExtractionService.extract(body.conversation_id, body.user_id)
+    return {"status": "ok"}

--- a/apps/api/src/coyo/services/cloud_tasks.py
+++ b/apps/api/src/coyo/services/cloud_tasks.py
@@ -1,0 +1,152 @@
+"""Cloud Tasks client for enqueuing background work.
+
+Falls back to asyncio.create_task() when Cloud Tasks is not configured
+(local development).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import structlog
+
+from coyo.config import get_settings
+
+if TYPE_CHECKING:
+    import uuid
+
+    from google.cloud import tasks_v2
+
+    from coyo.config import Settings
+
+logger = structlog.get_logger()
+
+# Strong references to background tasks to prevent GC during execution.
+# Used only in local fallback mode (asyncio.create_task).
+_background_tasks: set[asyncio.Task[None]] = set()
+
+# Cached Cloud Tasks client (lazy init, reuses gRPC channel).
+_cloud_tasks_client: tasks_v2.CloudTasksClient | None = None
+
+
+def _get_cloud_tasks_client() -> tasks_v2.CloudTasksClient:
+    """Return a cached CloudTasksClient singleton."""
+    global _cloud_tasks_client  # noqa: PLW0603
+    if _cloud_tasks_client is None:
+        from google.cloud import tasks_v2
+
+        _cloud_tasks_client = tasks_v2.CloudTasksClient()
+    return _cloud_tasks_client
+
+
+class CloudTasksService:
+    """Enqueue work via Cloud Tasks or fall back to asyncio."""
+
+    @staticmethod
+    async def enqueue_interest_extraction(
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Enqueue interest extraction for a completed conversation.
+
+        When Cloud Tasks is configured, creates an HTTP task targeting
+        the task handler endpoint. Otherwise, falls back to asyncio.create_task().
+        """
+        settings = get_settings()
+
+        if not settings.cloud_tasks_queue:
+            CloudTasksService._fallback_asyncio(conversation_id, user_id)
+            return
+
+        await CloudTasksService._enqueue_cloud_task(settings, conversation_id, user_id)
+
+    @staticmethod
+    def _fallback_asyncio(
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Local development fallback using asyncio.create_task."""
+        from coyo.services.interest_extraction import InterestExtractionService
+
+        logger.info(
+            "cloud_tasks_fallback_asyncio",
+            conversation_id=str(conversation_id),
+            user_id=str(user_id),
+        )
+        task = asyncio.create_task(
+            InterestExtractionService.extract_background(conversation_id, user_id)
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+    @staticmethod
+    async def _enqueue_cloud_task(
+        settings: Settings,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Create an HTTP task in Cloud Tasks.
+
+        Runs the blocking gRPC call in a thread to avoid blocking the event loop.
+        Errors are logged but not propagated, so the caller's response is not affected.
+        """
+        try:
+            result = await asyncio.to_thread(
+                CloudTasksService._create_task_sync,
+                settings,
+                conversation_id,
+                user_id,
+            )
+            logger.info(
+                "cloud_task_enqueued",
+                task_name=result.name,
+                conversation_id=str(conversation_id),
+                user_id=str(user_id),
+            )
+        except Exception:
+            logger.exception(
+                "cloud_task_enqueue_failed",
+                conversation_id=str(conversation_id),
+                user_id=str(user_id),
+            )
+
+    @staticmethod
+    def _create_task_sync(
+        settings: Settings,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> tasks_v2.Task:
+        """Blocking Cloud Tasks API call (run via asyncio.to_thread)."""
+        from google.cloud import tasks_v2
+
+        client = _get_cloud_tasks_client()
+        parent = client.queue_path(
+            settings.cloud_tasks_project,
+            settings.cloud_tasks_location,
+            settings.cloud_tasks_queue,
+        )
+
+        payload = json.dumps({
+            "conversation_id": str(conversation_id),
+            "user_id": str(user_id),
+        })
+
+        task_request = tasks_v2.CreateTaskRequest(
+            parent=parent,
+            task=tasks_v2.Task(
+                http_request=tasks_v2.HttpRequest(
+                    http_method=tasks_v2.HttpMethod.POST,
+                    url=f"{settings.cloud_run_service_url}/api/tasks/extract-interests",
+                    headers={"Content-Type": "application/json"},
+                    body=payload.encode(),
+                    oidc_token=tasks_v2.OidcToken(
+                        service_account_email="",  # Uses default SA
+                        audience=settings.cloud_run_service_url,
+                    ),
+                ),
+            ),
+        )
+
+        return client.create_task(request=task_request)

--- a/apps/api/src/coyo/services/conversation.py
+++ b/apps/api/src/coyo/services/conversation.py
@@ -1,6 +1,5 @@
 """Service layer for conversation lifecycle management."""
 
-import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -14,10 +13,6 @@ from coyo.models.conversation import Conversation
 from coyo.models.correction import TurnCorrection
 from coyo.models.turn import Turn
 from coyo.repositories.conversation import ConversationRepository
-
-# Strong references to background tasks to prevent GC during execution.
-# See: https://docs.python.org/3/library/asyncio-task.html#creating-tasks
-_background_tasks: set[asyncio.Task[None]] = set()
 
 ALLOWED_TOPICS: frozenset[str] = frozenset(
     {"sports", "business", "technology", "politics", "entertainment", "suggested"}
@@ -147,14 +142,10 @@ class ConversationService:
         )
         await self._session.commit()
 
-        # Background interest extraction (strong ref prevents GC)
-        from coyo.services.interest_extraction import InterestExtractionService
+        # Enqueue interest extraction (Cloud Tasks or asyncio fallback)
+        from coyo.services.cloud_tasks import CloudTasksService
 
-        task = asyncio.create_task(
-            InterestExtractionService.extract_background(conversation_id, user_id)
-        )
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
+        await CloudTasksService.enqueue_interest_extraction(conversation_id, user_id)
 
         # update_on_end already checked for None via get_by_id above
         return conversation  # type: ignore[return-value]

--- a/apps/api/src/coyo/services/interest_extraction.py
+++ b/apps/api/src/coyo/services/interest_extraction.py
@@ -101,6 +101,19 @@ class InterestExtractionService:
             )
 
     @staticmethod
+    async def extract(
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """Run interest extraction. Raises on failure for Cloud Tasks retry."""
+        session_factory = get_session_factory()
+        async with session_factory() as session:
+            await InterestExtractionService._extract(
+                session, conversation_id, user_id
+            )
+            await session.commit()
+
+    @staticmethod
     async def _extract(
         session: AsyncSession,
         conversation_id: uuid.UUID,
@@ -113,6 +126,14 @@ class InterestExtractionService:
             logger.warning(
                 "interest_extraction_conversation_not_found",
                 conversation_id=str(conversation_id),
+            )
+            return
+        if conversation.user_id != user_id:
+            logger.error(
+                "interest_extraction_user_mismatch",
+                conversation_id=str(conversation_id),
+                user_id=str(user_id),
+                actual_user_id=str(conversation.user_id),
             )
             return
         if conversation.interests_extracted:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -242,6 +242,10 @@ def mock_settings():
     mock.cors_allowed_origins = ["http://localhost:8081"]
     mock.max_audio_size_bytes = 10 * 1024 * 1024
     mock.rate_limit_per_minute = 30
+    mock.cloud_tasks_project = None
+    mock.cloud_tasks_location = None
+    mock.cloud_tasks_queue = None
+    mock.cloud_run_service_url = None
 
     with patch("coyo.config.get_settings", return_value=mock):
         yield mock

--- a/apps/api/tests/unit/test_cloud_tasks.py
+++ b/apps/api/tests/unit/test_cloud_tasks.py
@@ -1,0 +1,217 @@
+"""Unit tests for the CloudTasksService."""
+
+import asyncio
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from coyo.services.cloud_tasks import CloudTasksService, _background_tasks
+
+
+class TestEnqueueInterestExtraction:
+    """Tests for CloudTasksService.enqueue_interest_extraction."""
+
+    @pytest.mark.unit
+    async def test_enqueue_falls_back_to_asyncio_when_queue_not_configured(
+        self, mock_settings
+    ):
+        """When cloud_tasks_queue is None, should call _fallback_asyncio."""
+        mock_settings.cloud_tasks_queue = None
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        with (
+            patch(
+                "coyo.services.cloud_tasks.get_settings", return_value=mock_settings
+            ),
+            patch.object(CloudTasksService, "_fallback_asyncio") as mock_fallback,
+        ):
+            await CloudTasksService.enqueue_interest_extraction(conv_id, user_id)
+
+        mock_fallback.assert_called_once_with(conv_id, user_id)
+
+    @pytest.mark.unit
+    async def test_enqueue_creates_cloud_task_when_configured(self, mock_settings):
+        """When all cloud_tasks settings are set, should call _enqueue_cloud_task."""
+        mock_settings.cloud_tasks_queue = "my-queue"
+        mock_settings.cloud_tasks_project = "my-project"
+        mock_settings.cloud_tasks_location = "us-central1"
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        with (
+            patch(
+                "coyo.services.cloud_tasks.get_settings", return_value=mock_settings
+            ),
+            patch.object(
+                CloudTasksService, "_enqueue_cloud_task", new_callable=AsyncMock
+            ) as mock_enqueue,
+        ):
+            await CloudTasksService.enqueue_interest_extraction(conv_id, user_id)
+
+        mock_enqueue.assert_called_once_with(mock_settings, conv_id, user_id)
+
+
+class TestFallbackAsyncio:
+    """Tests for the asyncio fallback path."""
+
+    @pytest.mark.unit
+    async def test_fallback_asyncio_creates_task(self, mock_settings):
+        """Verify asyncio.create_task is called with extract_background."""
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        with patch(
+            "coyo.services.interest_extraction.InterestExtractionService.extract_background",
+            new_callable=AsyncMock,
+        ):
+            CloudTasksService._fallback_asyncio(conv_id, user_id)
+            # Allow the event loop to schedule the task
+            await asyncio.sleep(0)
+
+    @pytest.mark.unit
+    async def test_fallback_asyncio_adds_task_to_background_set(self, mock_settings):
+        """Verify the background task is added to _background_tasks set."""
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        initial_count = len(_background_tasks)
+
+        with patch(
+            "coyo.services.interest_extraction.InterestExtractionService.extract_background",
+            new_callable=AsyncMock,
+        ):
+            CloudTasksService._fallback_asyncio(conv_id, user_id)
+            # Task should be added immediately
+            assert len(_background_tasks) > initial_count
+
+            # Allow task to complete and be discarded
+            await asyncio.sleep(0.1)
+
+
+class TestCreateTaskSync:
+    """Tests for the synchronous Cloud Tasks API call."""
+
+    @pytest.mark.unit
+    def test_create_task_sync_calls_client(self, mock_settings):
+        """Should call CloudTasksClient.create_task with correct arguments."""
+        mock_settings.cloud_tasks_project = "my-project"
+        mock_settings.cloud_tasks_location = "us-central1"
+        mock_settings.cloud_tasks_queue = "my-queue"
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_client = MagicMock()
+        mock_client.queue_path.return_value = (
+            "projects/my-project/locations/us-central1/queues/my-queue"
+        )
+        mock_result = MagicMock()
+        mock_result.name = "projects/my-project/locations/us-central1/queues/my-queue/tasks/123"
+        mock_client.create_task.return_value = mock_result
+
+        with patch(
+            "coyo.services.cloud_tasks._get_cloud_tasks_client",
+            return_value=mock_client,
+        ):
+            result = CloudTasksService._create_task_sync(mock_settings, conv_id, user_id)
+
+        mock_client.queue_path.assert_called_once_with(
+            "my-project", "us-central1", "my-queue"
+        )
+        mock_client.create_task.assert_called_once()
+        assert result.name == mock_result.name
+
+    @pytest.mark.unit
+    def test_create_task_sync_payload_format(self, mock_settings):
+        """Verify the JSON payload contains conversation_id and user_id as strings."""
+        mock_settings.cloud_tasks_project = "my-project"
+        mock_settings.cloud_tasks_location = "us-central1"
+        mock_settings.cloud_tasks_queue = "my-queue"
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_client = MagicMock()
+        mock_client.queue_path.return_value = (
+            "projects/my-project/locations/us-central1/queues/my-queue"
+        )
+        mock_result = MagicMock()
+        mock_result.name = "tasks/123"
+        mock_client.create_task.return_value = mock_result
+
+        with patch(
+            "coyo.services.cloud_tasks._get_cloud_tasks_client",
+            return_value=mock_client,
+        ):
+            CloudTasksService._create_task_sync(mock_settings, conv_id, user_id)
+
+        # Extract the CreateTaskRequest passed to create_task
+        call_args = mock_client.create_task.call_args
+        task_request = call_args.kwargs.get("request") or call_args.args[0]
+        body = task_request.task.http_request.body
+        payload = json.loads(body.decode())
+
+        assert payload["conversation_id"] == str(conv_id)
+        assert payload["user_id"] == str(user_id)
+
+    @pytest.mark.unit
+    def test_create_task_sync_url_format(self, mock_settings):
+        """Verify the URL is {cloud_run_service_url}/api/tasks/extract-interests."""
+        mock_settings.cloud_tasks_project = "my-project"
+        mock_settings.cloud_tasks_location = "us-central1"
+        mock_settings.cloud_tasks_queue = "my-queue"
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_client = MagicMock()
+        mock_client.queue_path.return_value = (
+            "projects/my-project/locations/us-central1/queues/my-queue"
+        )
+        mock_result = MagicMock()
+        mock_result.name = "tasks/123"
+        mock_client.create_task.return_value = mock_result
+
+        with patch(
+            "coyo.services.cloud_tasks._get_cloud_tasks_client",
+            return_value=mock_client,
+        ):
+            CloudTasksService._create_task_sync(mock_settings, conv_id, user_id)
+
+        call_args = mock_client.create_task.call_args
+        task_request = call_args.kwargs.get("request") or call_args.args[0]
+        url = task_request.task.http_request.url
+
+        assert url == "https://my-service.run.app/api/tasks/extract-interests"
+
+
+class TestEnqueueCloudTaskErrorHandling:
+    """Tests for error handling in the Cloud Tasks enqueue path."""
+
+    @pytest.mark.unit
+    async def test_enqueue_cloud_task_logs_and_swallows_errors(self, mock_settings):
+        """When _create_task_sync raises, the error is logged but not propagated."""
+        mock_settings.cloud_tasks_project = "my-project"
+        mock_settings.cloud_tasks_location = "us-central1"
+        mock_settings.cloud_tasks_queue = "my-queue"
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        with patch.object(
+            CloudTasksService,
+            "_create_task_sync",
+            side_effect=RuntimeError("gRPC connection failed"),
+        ):
+            # Should NOT raise
+            await CloudTasksService._enqueue_cloud_task(
+                mock_settings, conv_id, user_id
+            )

--- a/apps/api/tests/unit/test_interest_extraction.py
+++ b/apps/api/tests/unit/test_interest_extraction.py
@@ -352,3 +352,89 @@ class TestExtract:
         await InterestExtractionService._extract(
             db_session, conversation.id, uuid.uuid4()
         )
+
+    @pytest.mark.unit
+    async def test_extract_user_mismatch_returns_without_processing(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """Should abort if conversation.user_id != provided user_id."""
+        conversation = Conversation(
+            user_id=test_user.id,
+            status="completed",
+            time_limit_seconds=1800,
+            started_at=datetime.now(UTC),
+        )
+        db_session.add(conversation)
+        await db_session.flush()
+
+        other_user_id = uuid.uuid4()
+        await InterestExtractionService._extract(
+            db_session, conversation.id, other_user_id
+        )
+
+        # conversation_count should NOT be incremented
+        await db_session.refresh(test_user)
+        assert test_user.conversation_count == 0
+        # interests_extracted should NOT be set
+        await db_session.refresh(conversation)
+        assert conversation.interests_extracted is False
+
+
+class TestExtractPublicMethod:
+    """Tests for the public extract() method used by Cloud Tasks."""
+
+    @pytest.mark.unit
+    async def test_extract_raises_on_failure(self, mock_settings):
+        """Unlike extract_background, extract() should propagate exceptions."""
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        with (
+            patch(
+                "coyo.services.interest_extraction.get_session_factory"
+            ) as mock_factory,
+            patch.object(
+                InterestExtractionService,
+                "_extract",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("DB connection lost"),
+            ),
+        ):
+            mock_factory.return_value = MagicMock(
+                __call__=MagicMock(return_value=mock_session)
+            )
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(RuntimeError, match="DB connection lost"):
+                await InterestExtractionService.extract(conv_id, user_id)
+
+    @pytest.mark.unit
+    async def test_extract_background_swallows_exceptions(self, mock_settings):
+        """extract_background should NOT propagate exceptions (logs only)."""
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        with (
+            patch(
+                "coyo.services.interest_extraction.get_session_factory"
+            ) as mock_factory,
+            patch.object(
+                InterestExtractionService,
+                "_extract",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("DB connection lost"),
+            ),
+        ):
+            mock_factory.return_value = MagicMock(
+                __call__=MagicMock(return_value=mock_session)
+            )
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            # Should NOT raise
+            await InterestExtractionService.extract_background(conv_id, user_id)

--- a/apps/api/tests/unit/test_tasks_router.py
+++ b/apps/api/tests/unit/test_tasks_router.py
@@ -1,0 +1,136 @@
+"""Unit tests for the tasks router (Cloud Tasks callback endpoint)."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.user import User
+
+
+@pytest.fixture
+async def tasks_client(
+    db_session: AsyncSession,
+    test_user: User,
+) -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with verify_cloud_task_token overridden.
+
+    The standard ``client`` fixture does not override verify_cloud_task_token,
+    so this fixture adds that override to allow unauthenticated test requests
+    to the /api/tasks/* endpoints.
+    """
+    from coyo.dependencies import get_current_user, get_db, verify_cloud_task_token
+    from coyo.main import app
+
+    async def override_get_db():
+        yield db_session
+
+    async def override_get_current_user():
+        return test_user
+
+    async def override_verify_cloud_task_token():
+        return None
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[verify_cloud_task_token] = override_verify_cloud_task_token
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+class TestExtractInterestsEndpoint:
+    """Tests for POST /api/tasks/extract-interests."""
+
+    @pytest.mark.unit
+    async def test_extract_interests_success(self, tasks_client: AsyncClient):
+        """POST with valid body returns 200 {"status": "ok"}."""
+        conv_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        with patch(
+            "coyo.routers.tasks.InterestExtractionService.extract",
+            new_callable=AsyncMock,
+        ):
+            response = await tasks_client.post(
+                "/api/tasks/extract-interests",
+                json={"conversation_id": conv_id, "user_id": user_id},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    @pytest.mark.unit
+    async def test_extract_interests_calls_extract(self, tasks_client: AsyncClient):
+        """Verify it calls InterestExtractionService.extract with correct args."""
+        conv_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        with patch(
+            "coyo.routers.tasks.InterestExtractionService.extract",
+            new_callable=AsyncMock,
+        ) as mock_extract:
+            await tasks_client.post(
+                "/api/tasks/extract-interests",
+                json={"conversation_id": str(conv_id), "user_id": str(user_id)},
+            )
+
+        mock_extract.assert_called_once_with(conv_id, user_id)
+
+    @pytest.mark.unit
+    async def test_extract_interests_invalid_body_missing_fields(
+        self, tasks_client: AsyncClient
+    ):
+        """Missing required fields returns 422."""
+        response = await tasks_client.post(
+            "/api/tasks/extract-interests",
+            json={},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_extract_interests_invalid_body_bad_uuid(
+        self, tasks_client: AsyncClient
+    ):
+        """Invalid UUID format returns 422."""
+        response = await tasks_client.post(
+            "/api/tasks/extract-interests",
+            json={"conversation_id": "not-a-uuid", "user_id": "also-bad"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_extract_interests_propagates_errors(
+        self, tasks_client: AsyncClient
+    ):
+        """When extract() raises, the error results in a 500 response.
+
+        The unhandled_error_handler in middleware catches non-CoyoError exceptions
+        and returns a 500 JSON response. In some Starlette/middleware configurations
+        the exception may propagate through the ASGI transport instead.
+        """
+        conv_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        with patch(
+            "coyo.routers.tasks.InterestExtractionService.extract",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("LLM timeout"),
+        ):
+            try:
+                response = await tasks_client.post(
+                    "/api/tasks/extract-interests",
+                    json={"conversation_id": conv_id, "user_id": user_id},
+                )
+                # If the middleware catches it, we get a 500
+                assert response.status_code == 500
+            except RuntimeError:
+                # If the exception propagates through the ASGI transport,
+                # that also confirms the error is not silently swallowed
+                pass

--- a/apps/api/tests/unit/test_verify_cloud_task_token.py
+++ b/apps/api/tests/unit/test_verify_cloud_task_token.py
@@ -1,0 +1,89 @@
+"""Unit tests for the verify_cloud_task_token dependency."""
+
+from unittest.mock import patch
+
+import pytest
+
+from coyo.dependencies import verify_cloud_task_token
+from coyo.exceptions import AuthenticationError
+
+
+class TestVerifyCloudTaskToken:
+    """Tests for OIDC token verification dependency."""
+
+    @pytest.mark.unit
+    async def test_skips_when_service_url_not_configured(self, mock_settings):
+        """When cloud_run_service_url is None, returns without error."""
+        mock_settings.cloud_run_service_url = None
+
+        # Should not raise even without Authorization header
+        await verify_cloud_task_token(authorization=None)
+
+    @pytest.mark.unit
+    async def test_raises_when_no_auth_header_in_production(self, mock_settings):
+        """When cloud_run_service_url is set but no Authorization header, raises."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with pytest.raises(AuthenticationError, match="Missing Authorization header"):
+            await verify_cloud_task_token(authorization=None)
+
+    @pytest.mark.unit
+    async def test_raises_on_invalid_bearer_format_no_space(self, mock_settings):
+        """When Authorization header has no space separator, raises."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with pytest.raises(AuthenticationError, match="Invalid Authorization header format"):
+            await verify_cloud_task_token(authorization="BearerNoSpace")
+
+    @pytest.mark.unit
+    async def test_raises_on_invalid_bearer_format_wrong_scheme(self, mock_settings):
+        """When Authorization header uses wrong scheme, raises."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with pytest.raises(AuthenticationError, match="Invalid Authorization header format"):
+            await verify_cloud_task_token(authorization="Basic some-creds")
+
+    @pytest.mark.unit
+    async def test_raises_on_invalid_oidc_token(self, mock_settings):
+        """When token verification fails, raises AuthenticationError."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with (
+            patch(
+                "coyo.dependencies._verify_oidc_token",
+                side_effect=ValueError("Token expired"),
+            ),
+            pytest.raises(AuthenticationError, match="Invalid OIDC token"),
+        ):
+            await verify_cloud_task_token(authorization="Bearer invalid-token")
+
+    @pytest.mark.unit
+    async def test_passes_with_valid_token(self, mock_settings):
+        """When token is valid, returns without error."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with patch(
+            "coyo.dependencies._verify_oidc_token",
+            return_value=None,
+        ):
+            # Should not raise
+            await verify_cloud_task_token(authorization="Bearer valid-token-123")
+
+    @pytest.mark.unit
+    async def test_bearer_case_insensitive(self, mock_settings):
+        """Bearer prefix should be case-insensitive."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with patch(
+            "coyo.dependencies._verify_oidc_token",
+            return_value=None,
+        ):
+            await verify_cloud_task_token(authorization="bearer valid-token-123")
+
+    @pytest.mark.unit
+    async def test_empty_authorization_string_raises(self, mock_settings):
+        """Empty string Authorization header raises."""
+        mock_settings.cloud_run_service_url = "https://my-service.run.app"
+
+        with pytest.raises(AuthenticationError, match="Invalid Authorization header format"):
+            await verify_cloud_task_token(authorization="")


### PR DESCRIPTION
## Summary

- Replace `asyncio.create_task()` fire-and-forget with **Cloud Tasks HTTP tasks** for production reliability (Cloud Run instance shutdown no longer loses in-flight extraction)
- **Local dev fallback**: when `CLOUD_TASKS_QUEUE` is not set, behavior is identical to before (asyncio)
- Add `POST /api/tasks/extract-interests` endpoint with **OIDC authentication** for Cloud Tasks callbacks
- Add config validator ensuring all 4 Cloud Tasks env vars are set together (prevents partial misconfiguration)
- Add user-conversation ownership check in extraction logic (IDOR prevention)

### New files
| File | Purpose |
|---|---|
| `services/cloud_tasks.py` | CloudTasksService — cached gRPC client, asyncio.to_thread, error-swallowing enqueue |
| `routers/tasks.py` | Task handler endpoint with OIDC auth dependency |
| `tests/unit/test_cloud_tasks.py` | 8 tests for CloudTasksService |
| `tests/unit/test_tasks_router.py` | 5 tests for task endpoint |
| `tests/unit/test_verify_cloud_task_token.py` | 8 tests for OIDC verification |

### Modified files
| File | Change |
|---|---|
| `config.py` | 4 Cloud Tasks settings + all-or-none validator |
| `dependencies.py` | `verify_cloud_task_token()` + shared `_extract_bearer_token()` |
| `interest_extraction.py` | `extract()` method (raises for retry) + user_id ownership check |
| `conversation.py` | `asyncio.create_task` → `CloudTasksService.enqueue_interest_extraction` |
| `main.py` | Register tasks router |

### Cloud Scheduler (infra only, no code changes)
`POST /api/topics/generate` already exists. Deploy with:
```bash
gcloud scheduler jobs create http coyo-topic-generation \
  --location=asia-northeast1 \
  --schedule="0 6 * * *" \
  --time-zone="Asia/Tokyo" \
  --uri="https://<SERVICE_URL>/api/topics/generate" \
  --http-method=POST \
  --headers="X-Cron-Secret=<SECRET>" \
  --attempt-deadline=300s
```

## Test plan

- [x] All 555 tests pass (531 existing + 24 new)
- [x] Ruff lint clean on all new/modified files
- [x] Manual verification: `POST /api/tasks/extract-interests` returns 200 with valid UUIDs
- [x] Manual verification: invalid input returns 422
- [x] Manual verification: OIDC skipped in local dev (no Authorization header needed)
- [x] Manual verification: endpoint registered in OpenAPI schema
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)