### PR TITLE
fix: include Docker containers in stop-dev.sh shutdown targets

### DIFF
--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# stop-dev.sh — Stop dev environment processes (API + Metro)
+# stop-dev.sh — Stop dev environment processes (API + Metro + Docker)
 #
 # Usage:
 #   ./scripts/stop-dev.sh          # Stop all dev processes
@@ -8,9 +8,7 @@
 # Stops:
 #   - Backend API (uvicorn) on port 8000
 #   - Metro bundler (Expo) on port 8081
-#
-# Docker containers (Postgres, Redis) are NOT stopped — they are shared
-# infrastructure and cheap to keep running. Use `make docker-down` to stop them.
+#   - Docker containers (Postgres + Redis)
 #
 # Safe to run when no processes are running (exits cleanly).
 
@@ -23,6 +21,7 @@ API_DIR="$REPO_ROOT/apps/api"
 # Source shared functions (provides API_PORT, METRO_PORT, kill_port_processes, logging)
 source "$REPO_ROOT/scripts/lib/common.sh"
 init_log "[stop]"
+init_worktree
 
 # ---------------------------------------------------------------------------
 # Main
@@ -43,5 +42,16 @@ stop_service() {
 echo ""
 stop_service "$API_PORT" "API (uvicorn)"
 stop_service "$METRO_PORT" "Metro bundler"
+
+# Stop Docker containers (Postgres + Redis)
+# NOTE: `docker compose ps` always prints a header line, so skip it with tail +2
+if docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" ps --status running 2>/dev/null | tail -n +2 | grep -q .; then
+  log "Stopping Docker containers..."
+  docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$_COMPOSE_PROJECT" down
+  log "Docker containers stopped."
+else
+  log "Docker containers: not running."
+fi
+
 echo ""
 log "Dev environment stopped."


### PR DESCRIPTION
## Summary

- `stop-dev.sh` now stops Docker containers (Postgres + Redis) in addition to API and Metro, matching the startup behavior of `run-dev.sh`
- Added `init_worktree` call for correct compose project name resolution when running from a worktree
- Header-only output from `docker compose ps` is properly skipped to avoid false-positive detection

## Test plan

- [x] Verified script stops running Docker containers correctly
- [x] Verified "not running" message when no containers are active
- [x] Verified worktree context resolves correct compose project name
- [x] Syntax check passed (`bash -n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)