### PR TITLE
fix: set explicit service_account_email for Cloud Tasks OIDC token

### DIFF
--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     cloud_tasks_location: str | None = None
     cloud_tasks_queue: str | None = None
     cloud_run_service_url: str | None = None
+    cloud_tasks_service_account: str | None = None
 
     # TTS Config
     tts_voice: str = "nova"
@@ -73,12 +74,13 @@ class Settings(BaseSettings):
             self.cloud_tasks_location,
             self.cloud_tasks_queue,
             self.cloud_run_service_url,
+            self.cloud_tasks_service_account,
         ]
         non_none = [f for f in fields if f is not None]
-        if non_none and len(non_none) != 4:
+        if non_none and len(non_none) != len(fields):
             raise ValueError(
                 "Cloud Tasks settings must be all set or all None. "
-                f"Got {len(non_none)}/4 configured."
+                f"Got {len(non_none)}/{len(fields)} configured."
             )
         return self
 

--- a/apps/api/src/coyo/services/cloud_tasks.py
+++ b/apps/api/src/coyo/services/cloud_tasks.py
@@ -142,7 +142,7 @@ class CloudTasksService:
                     headers={"Content-Type": "application/json"},
                     body=payload.encode(),
                     oidc_token=tasks_v2.OidcToken(
-                        service_account_email="",  # Uses default SA
+                        service_account_email=settings.cloud_tasks_service_account,
                         audience=settings.cloud_run_service_url,
                     ),
                 ),

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -246,6 +246,7 @@ def mock_settings():
     mock.cloud_tasks_location = None
     mock.cloud_tasks_queue = None
     mock.cloud_run_service_url = None
+    mock.cloud_tasks_service_account = None
 
     with patch("coyo.config.get_settings", return_value=mock):
         yield mock

--- a/docs/DEPLOY-TOPIC-SUGGESTION.md
+++ b/docs/DEPLOY-TOPIC-SUGGESTION.md
@@ -127,6 +127,15 @@ echo "Service URL: ${SERVICE_URL}"
 
 Update the service with Cloud Tasks and cron settings:
 
+Get the default Compute Engine service account email:
+
+```bash
+SA_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+echo "Service Account: ${SA_EMAIL}"
+```
+
+Update the service with Cloud Tasks and cron settings:
+
 ```bash
 gcloud run services update ${SERVICE_NAME} \
   --region ${REGION} \
@@ -134,7 +143,8 @@ gcloud run services update ${SERVICE_NAME} \
 CLOUD_TASKS_PROJECT=$(gcloud config get project),\
 CLOUD_TASKS_LOCATION=${REGION},\
 CLOUD_TASKS_QUEUE=interest-extraction,\
-CLOUD_RUN_SERVICE_URL=${SERVICE_URL}" \
+CLOUD_RUN_SERVICE_URL=${SERVICE_URL},\
+CLOUD_TASKS_SERVICE_ACCOUNT=${SA_EMAIL}" \
   --update-secrets "CRON_SECRET=cron-secret:latest"
 ```
 
@@ -146,9 +156,10 @@ CLOUD_RUN_SERVICE_URL=${SERVICE_URL}" \
 | `CLOUD_TASKS_LOCATION` | e.g. `asia-northeast1` | Cloud Tasks queue region |
 | `CLOUD_TASKS_QUEUE` | `interest-extraction` | Queue name |
 | `CLOUD_RUN_SERVICE_URL` | Cloud Run service URL | Task callback URL + OIDC audience |
+| `CLOUD_TASKS_SERVICE_ACCOUNT` | SA email | Service account for OIDC token in Cloud Tasks |
 | `CRON_SECRET` | Secret Manager | HMAC secret for `/api/topics/generate` |
 
-> **Note:** All 4 `CLOUD_TASKS_*` variables must be set together. The app validates this at startup and will fail if only some are configured.
+> **Note:** All 5 `CLOUD_TASKS_*` variables must be set together. The app validates this at startup and will fail if only some are configured.
 
 ## Step 6: Create Cloud Scheduler Job (Pipeline B)
 


### PR DESCRIPTION
## Summary

- **Root cause**: Cloud Tasks API rejects `service_account_email=""` with `400 service_account_email must be set.`
- **Fix**: Add `CLOUD_TASKS_SERVICE_ACCOUNT` env var and pass it to `OidcToken` explicitly
- Update config validator to check 5 fields (was 4)
- Update deployment docs with new env var

## Changes

| File | Change |
|---|---|
| `config.py` | Add `cloud_tasks_service_account` field, update validator |
| `cloud_tasks.py` | Use `settings.cloud_tasks_service_account` instead of `""` |
| `conftest.py` | Add mock for new field |
| `DEPLOY-TOPIC-SUGGESTION.md` | Add `CLOUD_TASKS_SERVICE_ACCOUNT` to env vars |

## Deployment

After merging, update Cloud Run:

```bash
PROJECT_NUMBER=$(gcloud projects describe $(gcloud config get project) --format='value(projectNumber)')
gcloud run services update coyo-api --region asia-northeast1 \
  --update-env-vars "CLOUD_TASKS_SERVICE_ACCOUNT=${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
```

## Test plan

- [x] 555 tests pass
- [x] Ruff lint clean
- [x] CI checks pass
- [ ] Deploy and verify Cloud Tasks queue receives tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)