### PR TITLE
Merge develop into main

### DIFF
--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     cloud_tasks_location: str | None = None
     cloud_tasks_queue: str | None = None
     cloud_run_service_url: str | None = None
+    cloud_tasks_service_account: str | None = None
 
     # TTS Config
     tts_voice: str = "nova"
@@ -73,12 +74,13 @@ class Settings(BaseSettings):
             self.cloud_tasks_location,
             self.cloud_tasks_queue,
             self.cloud_run_service_url,
+            self.cloud_tasks_service_account,
         ]
         non_none = [f for f in fields if f is not None]
-        if non_none and len(non_none) != 4:
+        if non_none and len(non_none) != len(fields):
             raise ValueError(
                 "Cloud Tasks settings must be all set or all None. "
-                f"Got {len(non_none)}/4 configured."
+                f"Got {len(non_none)}/{len(fields)} configured."
             )
         return self
 

--- a/apps/api/src/coyo/services/cloud_tasks.py
+++ b/apps/api/src/coyo/services/cloud_tasks.py
@@ -142,7 +142,7 @@ class CloudTasksService:
                     headers={"Content-Type": "application/json"},
                     body=payload.encode(),
                     oidc_token=tasks_v2.OidcToken(
-                        service_account_email="",  # Uses default SA
+                        service_account_email=settings.cloud_tasks_service_account,
                         audience=settings.cloud_run_service_url,
                     ),
                 ),

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -246,6 +246,7 @@ def mock_settings():
     mock.cloud_tasks_location = None
     mock.cloud_tasks_queue = None
     mock.cloud_run_service_url = None
+    mock.cloud_tasks_service_account = None
 
     with patch("coyo.config.get_settings", return_value=mock):
         yield mock

--- a/docs/DEPLOY-TOPIC-SUGGESTION.md
+++ b/docs/DEPLOY-TOPIC-SUGGESTION.md
@@ -127,6 +127,15 @@ echo "Service URL: ${SERVICE_URL}"
 
 Update the service with Cloud Tasks and cron settings:
 
+Get the default Compute Engine service account email:
+
+```bash
+SA_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+echo "Service Account: ${SA_EMAIL}"
+```
+
+Update the service with Cloud Tasks and cron settings:
+
 ```bash
 gcloud run services update ${SERVICE_NAME} \
   --region ${REGION} \
@@ -134,7 +143,8 @@ gcloud run services update ${SERVICE_NAME} \
 CLOUD_TASKS_PROJECT=$(gcloud config get project),\
 CLOUD_TASKS_LOCATION=${REGION},\
 CLOUD_TASKS_QUEUE=interest-extraction,\
-CLOUD_RUN_SERVICE_URL=${SERVICE_URL}" \
+CLOUD_RUN_SERVICE_URL=${SERVICE_URL},\
+CLOUD_TASKS_SERVICE_ACCOUNT=${SA_EMAIL}" \
   --update-secrets "CRON_SECRET=cron-secret:latest"
 ```
 
@@ -146,9 +156,10 @@ CLOUD_RUN_SERVICE_URL=${SERVICE_URL}" \
 | `CLOUD_TASKS_LOCATION` | e.g. `asia-northeast1` | Cloud Tasks queue region |
 | `CLOUD_TASKS_QUEUE` | `interest-extraction` | Queue name |
 | `CLOUD_RUN_SERVICE_URL` | Cloud Run service URL | Task callback URL + OIDC audience |
+| `CLOUD_TASKS_SERVICE_ACCOUNT` | SA email | Service account for OIDC token in Cloud Tasks |
 | `CRON_SECRET` | Secret Manager | HMAC secret for `/api/topics/generate` |
 
-> **Note:** All 4 `CLOUD_TASKS_*` variables must be set together. The app validates this at startup and will fail if only some are configured.
+> **Note:** All 5 `CLOUD_TASKS_*` variables must be set together. The app validates this at startup and will fail if only some are configured.
 
 ## Step 6: Create Cloud Scheduler Job (Pipeline B)
 


### PR DESCRIPTION
## Summary
- fix: set explicit `service_account_email` for Cloud Tasks OIDC token (#117)
- fix: correct Cloud Scheduler flag `--max-retry-count` to `--max-retry-attempts` (#116)

## Changes
- Add `cloud_tasks_service_account` config field and use it for OIDC token in Cloud Tasks service
- Update deploy docs with service account setup and corrected CLI flags
- Update config validation to dynamically count fields

## Test plan
- [ ] Verify Cloud Tasks OIDC token uses correct service account in staging
- [ ] Verify Cloud Scheduler job creation with `--max-retry-attempts` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)