### PR TITLE
fix: add waitForAnimationToEnd before sign-out detection in auth E2E test

### DIFF
--- a/apps/mobile/e2e/auth-sign-in.yaml
+++ b/apps/mobile/e2e/auth-sign-in.yaml
@@ -15,6 +15,9 @@ appId: to.coyo.app
 - launchApp:
     clearState: false
 
+# Wait for app to settle and auth state to resolve before checking visibility
+- waitForAnimationToEnd
+
 # If already signed in (Home screen visible), sign out first.
 # This handles the case where parallel test execution signed in before us.
 - runFlow:


### PR DESCRIPTION
## Summary
- Add `waitForAnimationToEnd` after `launchApp` in `auth-sign-in.yaml` to let the app resolve auth state before the `when: visible` check for the sign-out button
- Without this, Maestro's one-shot visibility check silently skips when the app is still loading, causing the test to timeout waiting for the Welcome screen
- Matches the pattern already used in `ensure-signed-in.yaml`

Closes #104

## Test plan
- [x] `make e2e-ios FLOW=auth-sign-in.yaml` — passed (signed-in state detected and handled)
- [x] `make e2e-android FLOW=auth-sign-in.yaml` — passed (signed-in state detected and handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)