### PR TITLE
feat: upgrade STT model from whisper-1 to gpt-4o-transcribe

### DIFF
--- a/apps/api/src/coyo/config.py
+++ b/apps/api/src/coyo/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     cloud_run_service_url: str | None = None
     cloud_tasks_service_account: str | None = None
 
+    # STT Config
+    stt_model: Literal[
+        "whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe",
+    ] = "gpt-4o-transcribe"
+
     # TTS Config
     tts_voice: str = "nova"
     tts_model: str = "tts-1"

--- a/apps/api/src/coyo/services/stt.py
+++ b/apps/api/src/coyo/services/stt.py
@@ -1,4 +1,6 @@
-"""Speech-to-text service using OpenAI Whisper API."""
+"""Speech-to-text service using OpenAI transcription API."""
+
+from typing import Any
 
 import structlog
 from openai import AsyncOpenAI
@@ -10,7 +12,7 @@ logger = structlog.get_logger()
 
 
 class STTService:
-    """Transcribes audio to text using OpenAI Whisper.
+    """Transcribes audio to text using OpenAI transcription models.
 
     Accepts raw audio bytes and returns the transcribed text.
     Raises STTRecognitionError if no speech is detected,
@@ -20,26 +22,31 @@ class STTService:
     def __init__(self) -> None:
         settings = get_settings()
         self._client = AsyncOpenAI(api_key=settings.openai_api_key)
+        self._model = settings.stt_model
 
     async def transcribe(
         self,
         audio_data: bytes,
         filename: str = "audio.m4a",
+        *,
+        prompt: str | None = None,
     ) -> str:
-        """Transcribe audio bytes using OpenAI Whisper.
+        """Transcribe audio bytes using OpenAI transcription API.
 
         Args:
             audio_data: Raw audio bytes from the client.
             filename: Filename hint for the audio format (determines content type).
+            prompt: Optional context hint to improve transcription accuracy
+                (e.g. topic keywords, proper nouns, prior conversation text).
 
         Returns:
             The transcribed text, stripped of leading/trailing whitespace.
 
         Raises:
             STTRecognitionError: If the transcription result is empty.
-            ExternalServiceError: If the Whisper API call fails.
+            ExternalServiceError: If the API call fails.
         """
-        logger.info("stt_transcribe_start", audio_bytes=len(audio_data))
+        logger.info("stt_transcribe_start", audio_bytes=len(audio_data), model=self._model)
 
         # Determine content type from filename extension
         content_types: dict[str, str] = {
@@ -53,11 +60,16 @@ class STTService:
         content_type = content_types.get(ext, "audio/mp4")
 
         try:
-            transcription = await self._client.audio.transcriptions.create(
-                model="whisper-1",
-                file=(filename, audio_data, content_type),
-                language="en",
-            )
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "file": (filename, audio_data, content_type),
+                # Coyo targets English conversation practice; hardcoded by design.
+                "language": "en",
+            }
+            if prompt:
+                kwargs["prompt"] = prompt
+
+            transcription = await self._client.audio.transcriptions.create(**kwargs)
         except Exception as exc:
             logger.error("stt_transcribe_failed", error=str(exc))
             raise ExternalServiceError("STT", str(exc)) from exc

--- a/apps/api/src/coyo/services/turn_orchestrator.py
+++ b/apps/api/src/coyo/services/turn_orchestrator.py
@@ -4,7 +4,7 @@ The turn orchestrator is the core of the real-time conversation flow.
 When the user submits audio, this service coordinates the following steps
 as a streaming SSE response:
 
-1. **STT** - Transcribe user audio via OpenAI Whisper
+1. **STT** - Transcribe user audio via OpenAI transcription API
    -> SSE event: stt_result
 
 2. **LLM Reply (streaming)** - Generate AI conversational reply
@@ -42,6 +42,9 @@ from coyo.services.tts import TTSService
 from coyo.services.web_search_filter import is_filler_turn, strip_citations
 
 logger = structlog.get_logger()
+
+_STT_CONTEXT_TURN_COUNT = 4
+_STT_MAX_PROMPT_CHARS = 800
 
 _CONVERSATION_SYSTEM_PROMPT = """\
 You are a friendly English conversation partner. The current topic is {topic}.
@@ -125,11 +128,17 @@ class TurnOrchestrator:
         log.info("turn_pipeline_start")
 
         # -- Step 1: STT transcription ------------------------------------
-        user_text = await self._stt.transcribe(audio_data, filename=audio_filename)
+        previous_turns = await self._turn_repo.get_by_conversation_id(
+            conversation_id,
+        )
+        stt_prompt = self._format_stt_prompt(previous_turns, topic)
+        user_text = await self._stt.transcribe(
+            audio_data, filename=audio_filename, prompt=stt_prompt,
+        )
         yield _make_event("stt_result", {"text": user_text})
 
         # -- Step 2: Save user turn to DB ---------------------------------
-        next_sequence = await self._get_next_sequence(conversation_id)
+        next_sequence = (previous_turns[-1].sequence + 1) if previous_turns else 1
         user_turn = await self._turn_repo.create(
             conversation_id=conversation_id,
             role="user",
@@ -293,12 +302,28 @@ class TurnOrchestrator:
         yield _make_event("turn_complete", {})
         log.info("greeting_pipeline_done")
 
-    async def _get_next_sequence(self, conversation_id: uuid.UUID) -> int:
-        """Determine the next sequence number for a conversation."""
-        turns = await self._turn_repo.get_by_conversation_id(conversation_id)
-        if not turns:
-            return 1
-        return turns[-1].sequence + 1
+    @staticmethod
+    def _format_stt_prompt(turns: list[Any], topic: str) -> str:
+        """Format a prompt hint for the STT model.
+
+        Combines the conversation topic with recent turn texts so the
+        transcription model can leverage context for better accuracy,
+        especially for proper nouns and domain-specific terms.
+        """
+        parts: list[str] = []
+
+        topic_label = topic if topic != "suggested" else "a trending news topic"
+        parts.append(f"Topic: {topic_label}.")
+
+        # Use the last few turns as context (token limit is 244 for Whisper,
+        # but gpt-4o-transcribe is more generous; keep it concise regardless)
+        recent_turns = turns[-_STT_CONTEXT_TURN_COUNT:]
+        for turn in recent_turns:
+            parts.append(turn.text)
+
+        prompt = " ".join(parts)
+        # Truncate to stay within model prompt token limits
+        return prompt[:_STT_MAX_PROMPT_CHARS]
 
     async def _build_messages(
         self,

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -248,6 +248,7 @@ def mock_settings():
     mock.database_url = TEST_DATABASE_URL
     mock.redis_url = "redis://localhost:6379"
     mock.openai_api_key = "test-api-key"
+    mock.stt_model = "gpt-4o-transcribe"
     mock.llm_conversation_model = "gpt-5-mini"
     mock.llm_correction_model = "gpt-5-mini"
     mock.tts_voice = "nova"

--- a/apps/api/tests/unit/test_stt.py
+++ b/apps/api/tests/unit/test_stt.py
@@ -146,8 +146,37 @@ class TestSTTService:
         assert file_tuple[0] == "audio.m4a"
 
     @pytest.mark.unit
-    async def test_transcribe_uses_whisper_model(self, stt_service, mock_openai_client):
-        """Verify that the Whisper model is used for transcription."""
+    async def test_transcribe_uses_configured_model(self, stt_service, mock_openai_client):
+        """Verify that the configured STT model is used for transcription."""
         await stt_service.transcribe(b"audio-data")
         call_args = mock_openai_client.audio.transcriptions.create.call_args
-        assert call_args.kwargs["model"] == "whisper-1"
+        assert call_args.kwargs["model"] == "gpt-4o-transcribe"
+
+    @pytest.mark.unit
+    async def test_transcribe_without_prompt_omits_prompt_param(
+        self, stt_service, mock_openai_client
+    ):
+        """Verify that prompt is not passed when not provided."""
+        await stt_service.transcribe(b"audio-data")
+        call_args = mock_openai_client.audio.transcriptions.create.call_args
+        assert "prompt" not in call_args.kwargs
+
+    @pytest.mark.unit
+    async def test_transcribe_with_prompt_passes_prompt_param(
+        self, stt_service, mock_openai_client
+    ):
+        """Verify that prompt is passed to the API when provided."""
+        await stt_service.transcribe(
+            b"audio-data", prompt="Topic: tennis. Jannik Sinner won the match.",
+        )
+        call_args = mock_openai_client.audio.transcriptions.create.call_args
+        assert call_args.kwargs["prompt"] == "Topic: tennis. Jannik Sinner won the match."
+
+    @pytest.mark.unit
+    async def test_transcribe_with_empty_prompt_omits_prompt_param(
+        self, stt_service, mock_openai_client
+    ):
+        """Verify that empty string prompt is not passed."""
+        await stt_service.transcribe(b"audio-data", prompt="")
+        call_args = mock_openai_client.audio.transcriptions.create.call_args
+        assert "prompt" not in call_args.kwargs

--- a/apps/api/tests/unit/test_stt_prompt.py
+++ b/apps/api/tests/unit/test_stt_prompt.py
@@ -1,0 +1,68 @@
+"""Unit tests for the STT prompt building logic in TurnOrchestrator."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from coyo.services.turn_orchestrator import TurnOrchestrator
+
+
+def _make_turn(text: str) -> SimpleNamespace:
+    """Create a minimal turn-like object with a text attribute."""
+    return SimpleNamespace(text=text)
+
+
+class TestFormatSttPrompt:
+    """Tests for TurnOrchestrator._format_stt_prompt static method."""
+
+    @pytest.mark.unit
+    def test_empty_conversation(self):
+        """Verify prompt contains only topic when no turns exist."""
+        result = TurnOrchestrator._format_stt_prompt([], "tennis")
+        assert result == "Topic: tennis."
+
+    @pytest.mark.unit
+    def test_fewer_than_four_turns(self):
+        """Verify all turns are included when fewer than 4 exist."""
+        turns = [_make_turn("Hello"), _make_turn("Hi there")]
+        result = TurnOrchestrator._format_stt_prompt(turns, "tennis")
+        assert result == "Topic: tennis. Hello Hi there"
+
+    @pytest.mark.unit
+    def test_more_than_four_turns_uses_last_four(self):
+        """Verify only the last 4 turns are included."""
+        turns = [
+            _make_turn("Turn 1"),
+            _make_turn("Turn 2"),
+            _make_turn("Turn 3"),
+            _make_turn("Turn 4"),
+            _make_turn("Turn 5"),
+            _make_turn("Turn 6"),
+        ]
+        result = TurnOrchestrator._format_stt_prompt(turns, "sports")
+        assert "Turn 1" not in result
+        assert "Turn 2" not in result
+        assert "Turn 3" in result
+        assert "Turn 4" in result
+        assert "Turn 5" in result
+        assert "Turn 6" in result
+
+    @pytest.mark.unit
+    def test_suggested_topic_label_substitution(self):
+        """Verify 'suggested' topic is replaced with descriptive label."""
+        result = TurnOrchestrator._format_stt_prompt([], "suggested")
+        assert result == "Topic: a trending news topic."
+
+    @pytest.mark.unit
+    def test_standard_topic_passthrough(self):
+        """Verify standard topics are passed through unchanged."""
+        result = TurnOrchestrator._format_stt_prompt([], "cooking")
+        assert result == "Topic: cooking."
+
+    @pytest.mark.unit
+    def test_prompt_truncated_to_max_length(self):
+        """Verify prompt is truncated when it exceeds the max character limit."""
+        long_text = "x" * 500
+        turns = [_make_turn(long_text) for _ in range(4)]
+        result = TurnOrchestrator._format_stt_prompt(turns, "tennis")
+        assert len(result) <= 800


### PR DESCRIPTION
## Summary
- Upgrade STT model from `whisper-1` to `gpt-4o-transcribe` for significantly improved transcription accuracy (WER: 10.6% → 2.46% at the same price)
- Add `prompt` parameter to STT service, passing conversation topic + recent turn history as context hints for better proper noun recognition
- Add configurable `stt_model` setting with Literal type validation
- Eliminate redundant DB query by reusing fetched turns for both STT prompt and sequence calculation

## Changes
- `apps/api/src/coyo/config.py` — Add `stt_model` config with Literal type constraint
- `apps/api/src/coyo/services/stt.py` — Use configurable model, accept optional `prompt` parameter
- `apps/api/src/coyo/services/turn_orchestrator.py` — Build STT prompt from topic + last 4 turns, inline sequence calculation
- `apps/api/tests/` — Add/update unit tests (594 total, all passing)

## Test plan
- [x] All 594 unit tests pass
- [x] STT prompt building tests cover: empty conversation, <4 turns, >4 turns, topic substitution, truncation
- [x] Manual testing on iOS Simulator confirmed improved proper noun recognition (e.g. "Jannik Sinner")
- [x] Code review, security review, and Python review all approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)