### PR TITLE
fix: update correction prompt to treat input as transcribed spoken English

### DIFF
--- a/apps/api/src/coyo/services/correction.py
+++ b/apps/api/src/coyo/services/correction.py
@@ -47,10 +47,26 @@ class CorrectionAnalysis(BaseModel):
 
 _CORRECTION_SYSTEM_PROMPT = """\
 You are an English language correction assistant. \
-Analyze the following user text for grammar, expression, and vocabulary errors.
+The input text is transcribed from a spoken English conversation, not written text. \
+Analyze it for genuine spoken-English errors only.
 
 Rules:
-- Only flag genuine errors. Natural, correct English should not be flagged.
+- The input is speech-to-text output. Judge it by spoken/colloquial norms, \
+NOT formal written-English standards.
+- Accept natural spoken patterns — do NOT flag these:
+  - Sentence fragments or incomplete thoughts (normal in conversation)
+  - Filler words and discourse markers ("um", "uh", "like", "you know", \
+"well", "so", "I mean")
+  - Informal contractions ("gonna", "wanna", "gotta", "kinda")
+  - Casual sentence structures and informal grammar that native speakers use
+  - Missing punctuation or capitalization (these are transcription artifacts)
+  - Repetitions or self-corrections ("I went to the — I went to the store")
+- Only flag errors that would sound wrong in spoken conversation:
+  - Incorrect verb tenses ("I goed" instead of "I went")
+  - Wrong prepositions ("interested for" instead of "interested in")
+  - Subject-verb agreement errors ("he don't" instead of "he doesn't")
+  - Vocabulary misuse (wrong word choice that changes meaning)
+  - Word order errors that sound unnatural in speech
 - Each error MUST be a separate item. Never combine multiple errors into one \
 item, even if they appear in the same sentence.
 - "original" and "corrected" must be the minimal fragment around the single \

--- a/apps/api/tests/unit/test_correction.py
+++ b/apps/api/tests/unit/test_correction.py
@@ -1,7 +1,7 @@
 """Unit tests for the CorrectionService."""
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -293,3 +293,51 @@ class TestCorrectionAnalysisSchema:
         )
         assert analysis.has_errors is False
         assert len(analysis.items) == 0
+
+
+class TestCorrectionPromptContent:
+    """Tests that _CORRECTION_SYSTEM_PROMPT contains spoken-English instructions."""
+
+    @pytest.mark.unit
+    def test_prompt_mentions_transcribed_spoken_context(self):
+        """Verify the prompt indicates input is transcribed spoken English."""
+        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+
+        prompt_lower = _CORRECTION_SYSTEM_PROMPT.lower()
+        assert "transcribed" in prompt_lower, (
+            "Prompt must mention that input is transcribed speech"
+        )
+        assert "spoken" in prompt_lower, (
+            "Prompt must mention spoken English context"
+        )
+
+    @pytest.mark.unit
+    def test_prompt_accepts_natural_spoken_patterns(self):
+        """Verify the prompt instructs to accept filler words, fragments, and contractions."""
+        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+
+        prompt_lower = _CORRECTION_SYSTEM_PROMPT.lower()
+        assert "filler" in prompt_lower, (
+            "Prompt must mention filler words as acceptable"
+        )
+        assert "fragment" in prompt_lower, (
+            "Prompt must mention sentence fragments as acceptable"
+        )
+        assert "contraction" in prompt_lower, (
+            "Prompt must mention contractions as acceptable"
+        )
+
+    @pytest.mark.unit
+    def test_prompt_contains_json_schema_instruction(self):
+        """Verify the prompt still includes the JSON output schema instruction."""
+        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+
+        assert "has_errors" in _CORRECTION_SYSTEM_PROMPT, (
+            "Prompt must reference the has_errors JSON field"
+        )
+        assert "corrected_text" in _CORRECTION_SYSTEM_PROMPT, (
+            "Prompt must reference the corrected_text JSON field"
+        )
+        assert "items" in _CORRECTION_SYSTEM_PROMPT, (
+            "Prompt must reference the items JSON field"
+        )


### PR DESCRIPTION
## Summary
- Updated `_CORRECTION_SYSTEM_PROMPT` in `apps/api/src/coyo/services/correction.py` to explicitly treat input as transcribed spoken English (speech-to-text output)
- Added rules to accept natural spoken patterns: filler words, sentence fragments, informal contractions, repetitions, and missing punctuation
- Only genuine spoken-English errors are now flagged (wrong tenses, wrong prepositions, subject-verb agreement, vocabulary misuse)
- Added prompt content tests to verify spoken-English context is preserved

Closes #102

## Test plan
- [x] Unit tests pass (12/12)
- [x] Prompt content tests verify "transcribed"/"spoken" context and acceptance of natural patterns
- [x] Lint and build verification pass
- [x] Code review, security review, and Python review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)