### PR TITLE
fix: show latest topic suggestions instead of filtering by today's date

### DIFF
--- a/apps/api/src/coyo/repositories/topic_suggestion.py
+++ b/apps/api/src/coyo/repositories/topic_suggestion.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import date
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.models.topic_suggestion import TopicSuggestion, UserTopicSuggestion
@@ -60,9 +60,23 @@ class TopicSuggestionRepository:
     async def get_suggestions_for_user(
         self,
         user_id: uuid.UUID,
-        target_date: date,
     ) -> list[tuple[TopicSuggestion, float]]:
-        """Get topic suggestions for a user on a given date, ordered by relevance."""
+        """Get topic suggestions from the most recent generated_date for a user.
+
+        Uses MAX(generated_date) to find the latest batch, ordered by relevance.
+        Returns an empty list if the user has no assigned suggestions (the MAX
+        subquery returns NULL, causing the equality filter to match no rows).
+        """
+        latest_date_subq = (
+            select(func.max(TopicSuggestion.generated_date))
+            .join(
+                UserTopicSuggestion,
+                UserTopicSuggestion.topic_suggestion_id == TopicSuggestion.id,
+            )
+            .where(UserTopicSuggestion.user_id == user_id)
+            .scalar_subquery()
+        )
+
         stmt = (
             select(TopicSuggestion, UserTopicSuggestion.relevance_score)
             .join(
@@ -71,7 +85,7 @@ class TopicSuggestionRepository:
             )
             .where(
                 UserTopicSuggestion.user_id == user_id,
-                TopicSuggestion.generated_date == target_date,
+                TopicSuggestion.generated_date == latest_date_subq,
             )
             .order_by(UserTopicSuggestion.relevance_score.desc())
         )

--- a/apps/api/src/coyo/routers/topics.py
+++ b/apps/api/src/coyo/routers/topics.py
@@ -1,7 +1,6 @@
 """Topic suggestion endpoints."""
 
 import hmac
-from datetime import date
 
 import structlog
 from fastapi import APIRouter, Depends, Header, Request
@@ -30,9 +29,7 @@ async def get_suggestions(
 ) -> TopicSuggestionsListResponse:
     """Get topic suggestions for the current user."""
     repo = TopicSuggestionRepository(db)
-    today = date.today()
-
-    suggestions = await repo.get_suggestions_for_user(user.id, today)
+    suggestions = await repo.get_suggestions_for_user(user.id)
 
     personal: list[TopicSuggestionResponse] = []
     trending: list[TopicSuggestionResponse] = []

--- a/apps/api/tests/unit/test_topics_router.py
+++ b/apps/api/tests/unit/test_topics_router.py
@@ -1,15 +1,10 @@
 """Unit tests for the topics router endpoints."""
 
 import uuid
-from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from coyo.models.user import User
-
 
 # ---------------------------------------------------------------------------
 # POST /api/topics/generate — cron endpoint


### PR DESCRIPTION
## Summary

- Replace exact date match (`generated_date == date.today()`) with `MAX(generated_date)` subquery in `get_suggestions_for_user()`
- This ensures the home screen always shows the most recent batch of topic suggestions regardless of server timezone

## Root Cause

The Cloud Scheduler cron runs at 06:00 JST, but Cloud Run uses UTC. When the UTC date differs from JST (e.g., 21:00 UTC = next day in JST), `date.today()` returns a different date than when topics were generated, causing the query to return empty results.

## Test plan

- [x] All 594 unit tests passing
- [x] Ruff lint clean on changed files
- [x] Manual verification: topic suggestions displayed on home screen in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)