### PR TITLE
fix: use explicit path for ruff in Python lint hook

### DIFF
--- a/.claude/hooks/post-python-lint.sh
+++ b/.claude/hooks/post-python-lint.sh
@@ -9,9 +9,9 @@ case "$file" in
   *) exit 0 ;;
 esac
 
-ruff check --fix "$file" >/dev/null 2>&1 || true
-ruff format "$file" >/dev/null 2>&1 || true
-diag="$(ruff check "$file" 2>&1 | head -20)"
+apps/api/.venv/bin/ruff check --fix "$file" >/dev/null 2>&1 || true
+apps/api/.venv/bin/ruff format "$file" >/dev/null 2>&1 || true
+diag="$(apps/api/.venv/bin/ruff check "$file" 2>&1 | head -20)"
 
 if [ -n "$diag" ]; then
   jq -Rn --arg msg "$diag" '{


### PR DESCRIPTION
## Summary
- The PostToolUse Python lint hook (`post-python-lint.sh`) called `ruff` without a path, but ruff is only installed inside the project venv (`apps/api/.venv/bin/ruff`), not globally
- Changed all `ruff` invocations to `apps/api/.venv/bin/ruff` so the hook works correctly in both the main repo and worktrees

## Test plan
- [x] Created a `.py` file with unused imports via Write tool
- [x] Verified ruff auto-removed unused imports and "All checks passed!" was returned as hook feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)