### PR TITLE
chore: add PreToolUse hook to block git commit --no-verify

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$(cat)"
+command="$(jq -r '.tool_input.command // empty' <<< "$input" 2>/dev/null)" || exit 0
+
+if [[ "$command" =~ git[[:space:]]+commit ]] && [[ "$command" =~ --no-verify|-n[[:space:]] ]]; then
+  echo "BLOCKED: git commit --no-verify is prohibited. Pre-commit hooks must always run. Fix the underlying issue instead of bypassing hooks." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash .claude/hooks/block-no-verify.sh"
+          },
+          {
+            "type": "command",
             "command": "bash .claude/hooks/pre-commit-test-reminder.sh"
           }
         ]


### PR DESCRIPTION
## Summary
- Add `block-no-verify.sh` PreToolUse hook that blocks `git commit --no-verify` and `git commit -n`
- Register the hook in `.claude/settings.json` before the existing pre-commit test reminder

## Test plan
- [x] Verified `git commit --no-verify` is blocked (exit 2)
- [x] Verified `git commit -n` is blocked (exit 2)
- [x] Verified normal `git commit -m` passes (exit 0)
- [x] Verified `git log --no-verify` is not affected (exit 0)
- [x] Verified empty/invalid JSON input passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)