### PR TITLE
chore: migrate Python package management from pip to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           version: "0.7.19"
           enable-cache: true
+          # No uv.lock yet (introduced in PR1b); key the cache off pyproject.toml.
+          cache-dependency-glob: "apps/api/pyproject.toml"
       - run: uv pip install --system "ruff>=0.9"
       - run: ruff check src/
 
@@ -102,6 +104,8 @@ jobs:
         with:
           version: "0.7.19"
           enable-cache: true
+          # No uv.lock yet (introduced in PR1b); key the cache off pyproject.toml.
+          cache-dependency-glob: "apps/api/pyproject.toml"
       - run: uv pip install --system -e ".[dev]"
       - run: pytest --tb=short
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff>=0.9
+      # SHA-pinned to v3.2.4 for supply-chain safety. Refresh with the SHA from
+      # https://github.com/astral-sh/setup-uv/releases when bumping the version.
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          version: "0.7.19"
+          enable-cache: true
+      - run: uv pip install --system "ruff>=0.9"
       - run: ruff check src/
 
   lint-mobile:
@@ -90,7 +96,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e ".[dev]"
+      # SHA-pinned to v3.2.4 for supply-chain safety. Refresh with the SHA from
+      # https://github.com/astral-sh/setup-uv/releases when bumping the version.
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          version: "0.7.19"
+          enable-cache: true
+      - run: uv pip install --system -e ".[dev]"
       - run: pytest --tb=short
 
   test-mobile:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      # SHA-pinned to v3.2.4 for supply-chain safety. Refresh with the SHA from
+      # https://github.com/astral-sh/setup-uv/releases when bumping the version.
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          version: "0.7.19"
+          enable-cache: true
+
       # Authenticate to GCP via Workload Identity Federation (no service account keys)
       - id: auth
         uses: google-github-actions/auth@v2
@@ -54,7 +61,7 @@ jobs:
       - name: Check pending migrations
         id: migration-check
         run: |
-          pip install -e "apps/api"
+          uv pip install --system -e "apps/api"
           cd apps/api
           if alembic check 2>&1 | grep -q "No new upgrade operations detected"; then
             echo "has_pending=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           version: "0.7.19"
           enable-cache: true
+          # No uv.lock yet (introduced in PR1b); key the cache off pyproject.toml.
+          cache-dependency-glob: "apps/api/pyproject.toml"
 
       # Authenticate to GCP via Workload Identity Federation (no service account keys)
       - id: auth

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ coyo/
 ### Prerequisites
 
 - Python 3.12+
+- [uv](https://docs.astral.sh/uv/) (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
 - Node.js 20+
 - Docker (Docker Desktop, OrbStack, or Colima)
 
@@ -44,9 +45,9 @@ make docker-up          # Start Postgres + Redis
 
 ```bash
 cd apps/api
-python -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 cp ../../.env.example .env  # Edit OPENAI_API_KEY with your real key
 make -C ../.. migrate       # Run database migrations
 uvicorn src.coyo.main:app --reload

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,22 +1,43 @@
-# Stage 1: Build dependencies
+# Stage 1: Build dependencies with uv
+#
+# IMPORTANT: The Python image tag MUST be identical in both the builder and
+# runtime stages. The builder produces a virtualenv whose internal symlinks
+# (e.g., python3.12) are tied to the builder's interpreter. If the runtime
+# tag drifts, those symlinks break and the container fails to start.
 FROM python:3.12-slim AS builder
 
+# Install uv from the official distroless image (digest-pinned for supply-chain safety).
+# To refresh: `docker buildx imagetools inspect ghcr.io/astral-sh/uv:<version>`
+COPY --from=ghcr.io/astral-sh/uv:0.7.19@sha256:2dcbc74e60ed6d842122ed538f5267c80e7cde4ff1b6e66a199b89972496f033 /uv /uvx /usr/local/bin/
+
 WORKDIR /app
+
+# uv settings:
+#   - UV_LINK_MODE=copy: avoid hardlink warnings when /tmp and /app are on different filesystems
+#   - UV_COMPILE_BYTECODE=1: precompile .pyc for faster startup
+#   - UV_PYTHON_DOWNLOADS=never: use the system Python (do not let uv download a managed one)
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    VIRTUAL_ENV=/app/.venv
 
 COPY pyproject.toml ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+RUN uv venv "$VIRTUAL_ENV" \
+    && uv pip install --no-cache .
 
 # Stage 2: Runtime
 FROM python:3.12-slim AS runtime
 
 WORKDIR /app
 
-# Copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Copy the prebuilt virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Make the venv binaries the default
+ENV PATH="/app/.venv/bin:$PATH" \
+    VIRTUAL_ENV=/app/.venv
 
 # Copy source code and alembic config
 COPY alembic.ini ./

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - Python 3.12+
+- [uv](https://docs.astral.sh/uv/) (`curl -LsSf https://astral.sh/uv/install.sh | sh`) — Python package manager
 - Node.js 20+
 - Docker (Docker Desktop, OrbStack, or Colima)
 - Maestro CLI (for E2E tests): `curl -Ls "https://get.maestro.mobile.dev" | bash`
@@ -26,9 +27,9 @@ make docker-up    # Postgres 16 + Redis 7 via Docker Compose
 
 ```bash
 cd apps/api
-python -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 make -C ../.. migrate   # Run database migrations
 ```
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -112,9 +112,9 @@ gcloud secrets add-iam-policy-binding openai-api-key \
 cd apps/api
 
 # Create virtual environment and install dependencies
-python3 -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e .
+uv pip install -e .
 
 # Run migrations against production database
 # NOTE: Use single quotes to avoid shell interpretation of special characters in password

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -149,9 +149,9 @@ make docker-reset && make migrate
 ```bash
 cd apps/api
 rm -rf .venv
-python3.12 -m venv .venv
+uv venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 ```
 
 ### TypeScript type mismatches

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -243,14 +243,14 @@ ensure_backend() {
   # Verify venv
   if [[ ! -x "$API_DIR/.venv/bin/python" ]]; then
     err "Python venv not found at $API_DIR/.venv"
-    err "Create it with: cd $API_DIR && python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'"
+    err "Create it with: cd $API_DIR && uv venv && uv pip install -e '.[dev]'"
     return 1
   fi
 
   local venv_python
   venv_python=$("$API_DIR/.venv/bin/python" -c "import sys; print(sys.executable)" 2>/dev/null || true)
   if [[ -z "$venv_python" ]]; then
-    err "Python venv is broken. Recreate with: cd $API_DIR && python3 -m venv .venv --clear && .venv/bin/pip install -e '.[dev]'"
+    err "Python venv is broken. Recreate with: cd $API_DIR && rm -rf .venv && uv venv && uv pip install -e '.[dev]'"
     return 1
   fi
 

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -19,7 +19,7 @@
 # Design decisions:
 #   - COPY, not symlink: worktree can freely modify deps (e.g., npm install
 #     a new package) without affecting the main repo
-#   - npm ci / pip install: derived artifacts are regenerated from lock files,
+#   - npm ci / uv pip install: derived artifacts are regenerated from manifests,
 #     so "losing" them on worktree cleanup is fine
 #   - Existing files are never overwritten (protect manual edits)
 
@@ -118,6 +118,11 @@ _setup_node_modules() {
 _setup_venv() {
   local api_dir="$_WT_REPO_ROOT/apps/api"
 
+  if ! command -v uv >/dev/null 2>&1; then
+    _wt_err "uv is required but not installed. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    return 1
+  fi
+
   # Remove broken symlink from old setup
   if [[ -L "$api_dir/.venv" && ! -d "$api_dir/.venv" ]]; then
     _wt_warn "Removing broken .venv symlink."
@@ -141,10 +146,10 @@ _setup_venv() {
     rm -rf "$api_dir/.venv"
   fi
 
-  _wt_log "Creating Python venv and installing dependencies..."
+  _wt_log "Creating Python venv and installing dependencies (uv)..."
   cd "$api_dir"
-  python3 -m venv .venv
-  .venv/bin/pip install -e '.[dev]' 2>&1 | tail -3
+  uv venv
+  uv pip install -e '.[dev]' 2>&1 | tail -3
   _wt_log ".venv created."
 }
 


### PR DESCRIPTION
## Summary

This is **PR1a of 3** in the supply-chain defense initiative. It only swaps the Python package manager (pip → uv) across local dev, worktree setup, CI, Docker build and Cloud Run deploy. **No behavioural change**: dependency resolution still reads `pyproject.toml` directly and no lockfile is introduced.

The cooldown enforcement (`--exclude-newer`), `uv.lock` and the uv wrapper will land in **PR1b**, with PR2 adding Claude Code hooks that block bypass attempts. This PR is the foundation those changes need.

## Why uv (and not stay on pip)

uv is the only mainstream Python package manager that supports a release-age cooldown (`--exclude-newer`), which is the mechanism we want to use to defend against the kind of supply-chain attack that hit `axios` recently. Doing the tool swap as its own PR keeps the next PR (lockfile + cooldown) reviewable in isolation.

## Changes

- **`apps/api/Dockerfile`**: builder stage uses uv (`uv venv && uv pip install`); runtime stage copies the prebuilt venv. The uv binary is pulled from a **digest-pinned** image (`ghcr.io/astral-sh/uv:0.7.19@sha256:2dcbc74...`) so the build cannot be hijacked by retagging.
- **`scripts/setup-worktree.sh`**: `_setup_venv()` now runs `uv venv && uv pip install` and fails fast with a clear error if uv is not installed.
- **`scripts/lib/common.sh`**: error messages that previously suggested `python3 -m venv && pip install` now point at the uv equivalent.
- **`.github/workflows/ci.yml`**: `lint-api` and `test-api` jobs install uv via `astral-sh/setup-uv`, **SHA-pinned to v3.2.4** (`caf0cab7...`) with `enable-cache: true`.
- **`.github/workflows/deploy-api.yml`**: migration check step uses `uv pip install --system` instead of `pip install`. Same SHA-pinned `setup-uv`.
- **Docs** (`README.md`, `docs/CONTRIB.md`, `docs/RUNBOOK.md`, `docs/DEPLOY.md`): setup instructions rewritten for uv. `uv` is now listed as a prerequisite next to Python 3.12+.

## What is intentionally **not** in this PR

- No `uv.lock` (PR1b)
- No `--exclude-newer` cooldown (PR1b)
- No `scripts/uv-install.sh` wrapper or `make api-lock` / `make api-install` (PR1b)
- No `apps/mobile/.npmrc` with `min-release-age` (PR1b)
- No Claude Code hooks (PR2)

## Test plan

- [x] `docker build -f apps/api/Dockerfile apps/api/` succeeds with the digest-pinned uv image
- [x] Built runtime image: `python -c "import coyo, fastapi, sqlalchemy, openai, uvicorn"` works
- [x] Built runtime image: `uvicorn --version` runs (binary on PATH)
- [x] `uv venv && uv pip install -e ".[dev]"` in a fresh worktree
- [x] `pytest --tb=short` against the uv-built venv (679 tests pass)
- [x] `ci.yml` / `deploy-api.yml` pass YAML lint
- [x] `bash -n scripts/setup-worktree.sh`
- [ ] **Post-merge**: trigger `deploy-api.yml` via `workflow_dispatch` from this branch (or develop after merge) to verify the GCP/Cloud Run path before the next regular release. Until that runs successfully, do not promote develop to main.

## Reviewer notes

- E2E tests are intentionally skipped — this PR only touches build/CI/infra; no user-visible behaviour changes (per the project's "E2E Test Required Criteria").
- Both `code-reviewer` and `security-reviewer` agents reviewed the diff. All Major/Medium findings were addressed in this PR (notably: `scripts/lib/common.sh` pip residue → uv, GHCR image digest pin, GitHub Action SHA pin, setup-uv cache enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)