### PR TITLE
feat: add Claude Code supply-chain speed-bump hooks

### DIFF
--- a/.claude/hooks/check-protected-files.sh
+++ b/.claude/hooks/check-protected-files.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# .claude/hooks/check-protected-files.sh — PreToolUse Edit/Write/MultiEdit hook.
+#
+# Speed bump that refuses Edit/Write/MultiEdit on the small set of files
+# whose contents enforce the supply-chain release-age cooldown. If any of
+# these files were silently rewritten through the agent, the wrapper /
+# lockfile / hook chain could be neutralised in a single tool call.
+#
+# Bash-side mutations (chmod, rm, mv, sed -i, ln, output redirection)
+# targeting the same files are blocked by the sibling Bash hook
+# (.claude/hooks/check-uv-install.sh).
+#
+# Protected files:
+#   apps/mobile/.npmrc                       JS cooldown setting
+#   scripts/uv-install.sh                    uv wrapper that injects --exclude-newer
+#   scripts/install-npm-pinned.sh            integrity-pinned npm installer
+#   .claude/hooks/check-uv-install.sh        Bash sibling hook (self-defense)
+#   .claude/hooks/check-protected-files.sh   this hook (self-defense)
+#
+# Intentionally NOT protected:
+#   .claude/settings.json — Claude must be able to evolve its own hook
+#                            wiring; this is an explicit project decision
+#                            (see PR2 confirmation point 5). The trade-off
+#                            is that the hook configuration itself is
+#                            considered out of scope for self-defense and
+#                            is instead protected by code review on PRs.
+#
+# To legitimately edit a protected file (e.g., bumping the pinned npm
+# version, updating the wrapper for a new uv release), see
+# docs/CONTRIB.md "Supply-chain defense" for the session-disable procedure.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Fail-CLOSED on any preflight error.
+# -----------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED by .claude/hooks/check-protected-files.sh:" >&2
+  echo "  jq is not installed; the supply-chain hook cannot inspect the edit." >&2
+  echo "  Install jq (brew install jq / apt install jq) or disable the hook." >&2
+  exit 2
+fi
+
+input="$(cat)"
+file="$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$input" 2>/dev/null || true)"
+[[ -z "$file" ]] && exit 0  # not a file-bearing tool
+
+# -----------------------------------------------------------------------------
+# Try to resolve symlinks (best-effort, portable across macOS and Linux).
+# os.path.realpath works on non-existent files too (important for Write).
+# If python3 is missing, fall back to the original path — the suffix glob
+# below still catches direct edits.
+# -----------------------------------------------------------------------------
+
+resolved="$file"
+if command -v python3 >/dev/null 2>&1; then
+  if r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$file" 2>/dev/null)"; then
+    [[ -n "$r" ]] && resolved="$r"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Match each candidate path against the protected suffix list. Both the
+# original input path and the symlink-resolved path are checked, so
+# ln-based misdirection is caught.
+# -----------------------------------------------------------------------------
+
+is_protected() {
+  case "$1" in
+    apps/mobile/.npmrc | */apps/mobile/.npmrc \
+    | scripts/uv-install.sh | */scripts/uv-install.sh \
+    | scripts/install-npm-pinned.sh | */scripts/install-npm-pinned.sh \
+    | .claude/hooks/check-uv-install.sh | */.claude/hooks/check-uv-install.sh \
+    | .claude/hooks/check-protected-files.sh | */.claude/hooks/check-protected-files.sh)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+block() {
+  cat >&2 <<EOF
+BLOCKED by .claude/hooks/check-protected-files.sh (supply-chain speed bump):
+  $1
+
+This file enforces the supply-chain release-age cooldown introduced in
+PR1a/1b. Editing it through Claude is disabled to prevent the cooldown
+from being silently neutralised.
+
+If this edit is legitimate (e.g., bumping the pinned npm version,
+updating the wrapper for a new uv release), see docs/CONTRIB.md
+"Supply-chain defense" for the session-disable procedure.
+EOF
+  exit 2
+}
+
+if is_protected "$file"; then
+  block "$file"
+fi
+
+if [[ "$resolved" != "$file" ]] && is_protected "$resolved"; then
+  block "$file → $resolved (resolved through symlink)"
+fi
+
+exit 0

--- a/.claude/hooks/check-uv-install.sh
+++ b/.claude/hooks/check-uv-install.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# .claude/hooks/check-uv-install.sh — PreToolUse Bash hook (speed bump).
+#
+# WHAT THIS IS
+#   A "speed bump" that catches accidental, plain-text invocations of uv/pip
+#   commands which would bypass the supply-chain release-age cooldown enforced
+#   by apps/api/uv.lock and apps/mobile/.npmrc.
+#
+# WHAT THIS IS NOT
+#   A security boundary against a motivated or compromised actor. Regex on a
+#   shell command string cannot reliably understand variable expansion,
+#   string concatenation, eval, $(), backticks, heredocs, PATH shadowing,
+#   indirect interpreters, or "rewrite the hook config in settings.json".
+#   Real supply-chain enforcement lives in:
+#     - apps/api/uv.lock + uv sync --frozen everywhere (PR1a/1b)
+#     - apps/mobile/.npmrc min-release-age + engine-strict (PR1b)
+#     - CI hash-pin on the wrappers and these hook scripts (PR2)
+#     - Code review on .claude/settings.json changes
+#
+# Sanctioned entry points (the hook lets these through):
+#     make api-lock                  → regenerate uv.lock with the cooldown
+#     make api-install               → uv sync --frozen --extra dev
+#     bash scripts/uv-install.sh ... → wrapper that injects --exclude-newer
+#     bash scripts/install-npm-pinned.sh
+#     uv sync --frozen ...           → restore from the lockfile
+#     uv venv / uv run / uv --version → no resolution, no cooldown needed
+#
+# What the hook blocks (each is a "common accident" Claude might emit):
+#     uv pip install / uv pip compile / uv pip sync / uv pip uninstall
+#     uv add / uv lock
+#     uv sync (without --frozen)
+#     uv tool install / uv tool run / uvx
+#     pip install (pip, pip3, python -m pip, python3 -m pip)
+#     bash -c / sh -c / eval / python -c   when the inner string mentions
+#       any of the above
+#     chmod / rm / mv / cp / sed -i / tee / ln / output redirection (>, >>)
+#       targeting any file in the protected list (so the hook cannot be
+#       silently disabled by `chmod -x`-ing it from Bash)
+#
+# Known limitations (intentionally not chased — see "What this is not"):
+#     - Variable expansion: `U=uv; $U pip install evil` is NOT caught
+#     - String concatenation: `"u""v" pip install evil` is NOT caught
+#     - Indirect via PATH-shadowing or aliases is NOT caught
+#     - Editing .claude/settings.json to remove the hook is NOT caught
+#       (this was an explicit project decision to keep settings.json editable)
+#
+# To legitimately edit a protected file or run an off-list uv command for
+# a one-off task, see docs/CONTRIB.md "Supply-chain defense" for the
+# session-disable procedure.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Fail-CLOSED on any error: if jq is missing, the JSON is malformed, or any
+# preflight check fails, refuse the tool call rather than falling through.
+# A silent fail-open here would defeat the entire purpose of the hook.
+# -----------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED by .claude/hooks/check-uv-install.sh:" >&2
+  echo "  jq is not installed; the supply-chain hook cannot inspect the command." >&2
+  echo "  Install jq (brew install jq / apt install jq) or disable the hook." >&2
+  exit 2
+fi
+
+input="$(cat)"
+command="$(jq -r '.tool_input.command // empty' <<< "$input" 2>/dev/null || true)"
+[[ -z "$command" ]] && exit 0  # not a Bash invocation
+
+block() {
+  cat >&2 <<EOF
+BLOCKED by .claude/hooks/check-uv-install.sh (supply-chain speed bump):
+  $1
+
+This command would bypass the release-age cooldown that PR1a/1b baked
+into apps/api/uv.lock and apps/mobile/.npmrc. Use one of the sanctioned
+entry points instead:
+
+  make api-lock         # regenerate uv.lock with the 7-day cooldown
+  make api-install      # uv sync --frozen from the lockfile
+
+For one-off legitimate cases that can't go through these paths, see
+docs/CONTRIB.md "Supply-chain defense" for the session-disable procedure.
+EOF
+  exit 2
+}
+
+# -----------------------------------------------------------------------------
+# Pattern set 1: forbidden uv subcommands (token sequence anywhere in the
+# command, including chained commands like `cd foo && uv pip install bar`).
+#
+# The lead-in character class includes whitespace, common shell separators,
+# `(` for $() / process substitution, and backtick for `…` substitution.
+# -----------------------------------------------------------------------------
+
+LEAD='(^|[[:space:]\;\&\|\(\`])'
+
+# uv pip install / compile / sync / uninstall — direct Python deps install.
+if [[ "$command" =~ ${LEAD}uv[[:space:]]+pip[[:space:]]+(install|compile|sync|uninstall) ]]; then
+  block "uv pip ${BASH_REMATCH[2]} detected"
+fi
+
+# uv add — adds a dep without --exclude-newer.
+if [[ "$command" =~ ${LEAD}uv[[:space:]]+add([[:space:]]|$) ]]; then
+  block "uv add detected"
+fi
+
+# uv remove — removes a dep AND triggers a re-resolve, same risk as add.
+if [[ "$command" =~ ${LEAD}uv[[:space:]]+remove([[:space:]]|$) ]]; then
+  block "uv remove detected (use scripts/uv-install.sh remove via make api-lock)"
+fi
+
+# uv lock — regenerating the lockfile must go through scripts/uv-install.sh
+# (which is invoked as `bash scripts/uv-install.sh lock`, never `uv lock`).
+if [[ "$command" =~ ${LEAD}uv[[:space:]]+lock([[:space:]]|$) ]]; then
+  block "uv lock detected (use 'make api-lock' instead)"
+fi
+
+# uv tool install / uv tool run — moral equivalent of `pip install --user`,
+# downloads from PyPI with no cooldown.
+if [[ "$command" =~ ${LEAD}uv[[:space:]]+tool[[:space:]]+(install|run|upgrade) ]]; then
+  block "uv tool ${BASH_REMATCH[2]} detected"
+fi
+
+# uvx — ephemeral tool execution; downloads from PyPI on first use.
+if [[ "$command" =~ ${LEAD}uvx([[:space:]]|$) ]]; then
+  block "uvx detected (downloads tools without the cooldown)"
+fi
+
+# uv sync (without --frozen). We extract the segment from `uv sync` to the
+# next shell separator, strip any line comment, then look for `--frozen` as
+# a STANDALONE TOKEN (so `--frozen-mode` doesn't accidentally allow it).
+if [[ "$command" =~ uv[[:space:]]+sync[^\&\|\;]* ]]; then
+  uv_sync_segment="${BASH_REMATCH[0]}"
+  # Strip a `# comment` tail if present (defends against `uv sync # --frozen`).
+  uv_sync_segment_clean="${uv_sync_segment%%#*}"
+  if ! [[ "$uv_sync_segment_clean" =~ (^|[[:space:]])--frozen([[:space:]=]|$) ]]; then
+    block "uv sync without --frozen detected"
+  fi
+fi
+
+# pip install in any of its forms.
+if [[ "$command" =~ ${LEAD}(python[23]?[[:space:]]+-m[[:space:]]+)?pip[23]?[[:space:]]+install ]]; then
+  block "pip install detected"
+fi
+
+# -----------------------------------------------------------------------------
+# Pattern set 2: indirect-execution wrappers that contain a forbidden inner
+# command. We do not try to chase variable expansion or alias indirection;
+# we only catch the direct, plain-text "bash -c '... uv pip install ...'"
+# class of accidents (per the project's "speed bump" positioning).
+# -----------------------------------------------------------------------------
+
+# bash -c / sh -c with uv/pip inside the quoted string.
+# (\b word boundaries are not reliable in bash POSIX ERE on macOS, so we
+# rely on greedy `.*` + the explicit token shapes in the alternation.)
+if [[ "$command" =~ (bash|sh)[[:space:]]+-c[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
+  block "indirect uv/pip via ${BASH_REMATCH[1]} -c detected"
+fi
+
+# eval with uv/pip inside the quoted string.
+if [[ "$command" =~ eval[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
+  block "indirect uv/pip via eval detected"
+fi
+
+# python -c with pip / subprocess in the inline script.
+if [[ "$command" =~ python[23]?[[:space:]]+-c[[:space:]]+[\"\'].*(pip|subprocess|os\.exec|__import__) ]]; then
+  block "python -c with pip/subprocess detected"
+fi
+
+# -----------------------------------------------------------------------------
+# Pattern set 3: file mutation against any protected file. The Edit hook
+# only sees Edit/Write/MultiEdit; bare `rm`, `chmod -x`, `sed -i` etc. would
+# otherwise let an actor disable the wrappers or hooks themselves from Bash.
+# -----------------------------------------------------------------------------
+
+PROTECTED='(apps/mobile/\.npmrc|scripts/uv-install\.sh|scripts/install-npm-pinned\.sh|\.claude/hooks/check-uv-install\.sh|\.claude/hooks/check-protected-files\.sh)'
+
+# chmod / rm / mv / cp / tee / truncate <flags...> <protected-path>
+if [[ "$command" =~ (^|[[:space:]\;\&\|\(\`])(chmod|rm|mv|cp|tee|truncate)[[:space:]][^\&\|\;]*${PROTECTED} ]]; then
+  block "${BASH_REMATCH[2]} targeting protected file detected"
+fi
+
+# sed -i (in-place edit)
+if [[ "$command" =~ sed[[:space:]]+(-i|--in-place)[^\&\|\;]*${PROTECTED} ]]; then
+  block "sed -i targeting protected file detected"
+fi
+
+# ln (creating a symlink at, or to, a protected path — both directions risky)
+if [[ "$command" =~ (^|[[:space:]\;\&\|\(\`])ln[[:space:]][^\&\|\;]*${PROTECTED} ]]; then
+  block "ln targeting protected file detected"
+fi
+
+# Output redirection: > or >> targeting a protected path.
+if [[ "$command" =~ \>+[[:space:]]*[^\&\|\;]*${PROTECTED} ]]; then
+  block "output redirection to protected file detected"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,24 @@
             "command": "bash .claude/hooks/pre-commit-test-reminder.sh"
           }
         ]
+      },
+      {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-uv-install.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\" || tool == \"Write\" || tool == \"MultiEdit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-protected-files.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [develop]
-    paths:
-      - 'apps/**'
-      - '.github/workflows/ci.yml'
-      - 'Makefile'
-      - 'scripts/uv-install.sh'
-      - 'scripts/test/**'
   push:
     branches: [develop]
-    paths:
-      - 'apps/**'
-      - '.github/workflows/ci.yml'
-      - 'Makefile'
-      - 'scripts/uv-install.sh'
-      - 'scripts/test/**'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -42,6 +30,23 @@ jobs:
               - 'apps/mobile/**'
               - '.github/workflows/ci.yml'
 
+  hook-integrity:
+    name: Supply-chain hook integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Verify the wrappers, hooks, and their tests have not been mutated.
+      # If this fails, regenerate .security/hook-hashes.sha256 with:
+      #   sha256sum .claude/hooks/check-uv-install.sh \
+      #             .claude/hooks/check-protected-files.sh \
+      #             scripts/uv-install.sh \
+      #             scripts/install-npm-pinned.sh \
+      #             scripts/test/test-claude-hooks.sh \
+      #             scripts/test/test-uv-install.sh \
+      #     > .security/hook-hashes.sha256
+      # and request a code-owner review on the PR.
+      - run: sha256sum -c .security/hook-hashes.sha256
+
   wrapper-tests:
     name: Supply-chain wrapper tests
     runs-on: ubuntu-latest
@@ -52,6 +57,13 @@ jobs:
         with:
           version: "0.7.19"
       - run: bash scripts/test/test-uv-install.sh
+
+  hook-tests:
+    name: Claude Code hook tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/test/test-claude-hooks.sh
 
   lint-api:
     name: Lint API

--- a/.security/hook-hashes.sha256
+++ b/.security/hook-hashes.sha256
@@ -1,0 +1,6 @@
+a372bfe34e95da56aea69fe789692ec0c3027eac6c29bb967356d939eb7c1480  .claude/hooks/check-uv-install.sh
+ab3e942c6ee38271e51b83b0d881e21e0a4607b4afe3d5cbfdea9308c1304745  .claude/hooks/check-protected-files.sh
+8329945d91a58b298e969d1619e0c525efb9537703060bba71b8a1493ef41fe6  scripts/uv-install.sh
+1b74dda7003ccd2d39981e6f3f85a4f5044d7339e27bc3e068ad4d687b80b6e3  scripts/install-npm-pinned.sh
+4554d5e84aebc74389877f8df2e8d99820d9519000339adcc7b930563deea0e5  scripts/test/test-claude-hooks.sh
+bf5661dab74159cc64cd5354ea28e8f83517141f7e5d7ae99027efa5a0491cdc  scripts/test/test-uv-install.sh

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -23,8 +23,82 @@ this repo enforces a **release-age cooldown** on new dependencies:
   `npm install` / `npm ci` will refuse to install packages younger than 7 days.
   This requires npm >= 11.10.0 (see Prerequisites above).
 
-A pre-commit / Claude Code hook will be added in a follow-up PR to block any
-direct bypass of these guardrails.
+### Claude Code hooks (speed bump, not a security boundary)
+
+For sessions that use Claude Code, two `PreToolUse` hooks (wired in
+`.claude/settings.json`) catch **accidental** invocations that would
+bypass the cooldown:
+
+- **`.claude/hooks/check-uv-install.sh`** — refuses Bash commands that
+  invoke `uv pip install` / `uv pip compile|sync|uninstall`, `uv add`,
+  `uv remove`, `uv lock`, `uv sync` (without `--frozen`),
+  `uv tool install|run|upgrade`, `uvx`, or `pip install`. Also refuses
+  `bash -c '...'` / `sh -c '...'` / `eval '...'` / `python -c '...'` when
+  the inner string mentions any of the above. Also refuses Bash file
+  mutations (`chmod`, `rm`, `mv`, `cp`, `sed -i`, `tee`, `ln`, `>`/`>>`)
+  that target any protected file, so the hook cannot be silently disabled
+  by `chmod -x .claude/hooks/check-uv-install.sh`.
+- **`.claude/hooks/check-protected-files.sh`** — refuses Edit/Write/MultiEdit
+  on the files that enforce the policy: `apps/mobile/.npmrc`,
+  `scripts/uv-install.sh`, `scripts/install-npm-pinned.sh`, and the two
+  hook scripts themselves. Symlink targets are resolved before matching.
+
+The sanctioned entry points are `make api-lock`, `make api-install`,
+`bash scripts/uv-install.sh`, `bash scripts/install-npm-pinned.sh`, and
+the no-resolution uv subcommands (`uv venv`, `uv run`, `uv sync --frozen`,
+`uv --version`).
+
+> **What these hooks are NOT:** a security boundary against a motivated
+> or compromised actor. Regex over a shell command string cannot reliably
+> understand variable expansion (`U=uv; $U pip install …`), string
+> concatenation, PATH shadowing, aliases, indirect interpreters, or
+> "edit `.claude/settings.json` to remove the hook entries". Real
+> supply-chain enforcement lives in `apps/api/uv.lock` + `uv sync --frozen`
+> everywhere (PR1a/1b), `apps/mobile/.npmrc` + `engine-strict=true`
+> (PR1b), the SHA-256 integrity check on the hook + wrapper scripts in
+> `.security/hook-hashes.sha256` (verified by CI), and code review on
+> `.claude/settings.json` changes.
+
+#### Updating a protected file legitimately
+
+To bump the pinned npm version, update the wrapper for a new uv release,
+or otherwise edit a protected file or run an off-list uv command for a
+one-off task:
+
+1. **Disable the hook for your session** by writing to
+   `.claude/settings.local.json` (gitignored, so the override stays on
+   your machine and never lands in a commit):
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": []
+     }
+   }
+   ```
+2. **Make the edit / run the command.**
+3. **Re-run the smoke tests** to confirm nothing regressed:
+   ```bash
+   bash scripts/test/test-claude-hooks.sh
+   bash scripts/test/test-uv-install.sh
+   ```
+4. **Regenerate the integrity hashes** if you touched any of the protected
+   files (otherwise CI will fail with a hash mismatch):
+   ```bash
+   sha256sum .claude/hooks/check-uv-install.sh \
+             .claude/hooks/check-protected-files.sh \
+             scripts/uv-install.sh \
+             scripts/install-npm-pinned.sh \
+             scripts/test/test-claude-hooks.sh \
+             scripts/test/test-uv-install.sh \
+       > .security/hook-hashes.sha256
+   ```
+5. **Revert the local override** by deleting the `PreToolUse` entry from
+   `.claude/settings.local.json` (or removing the file entirely).
+
+Both hooks are smoke-tested by `scripts/test/test-claude-hooks.sh` and
+the wrapper by `scripts/test/test-uv-install.sh`, both of which run in CI
+on every PR. The integrity check (`sha256sum -c .security/hook-hashes.sha256`)
+runs in the same CI workflow.
 
 ## Environment Setup
 

--- a/scripts/test/test-claude-hooks.sh
+++ b/scripts/test/test-claude-hooks.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# scripts/test/test-claude-hooks.sh — smoke + adversarial test for the
+# Claude Code supply-chain hooks (.claude/hooks/check-uv-install.sh and
+# .claude/hooks/check-protected-files.sh).
+#
+# This is a "speed bump" test suite, not a security test suite — the
+# adversarial section deliberately covers only the patterns the hooks are
+# claimed to catch (per docs/CONTRIB.md). Bypasses via variable expansion,
+# string concatenation, PATH shadowing, and similar are KNOWN limitations
+# documented in the hook headers and not asserted here.
+#
+# Run manually or from CI:
+#   bash scripts/test/test-claude-hooks.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BASH_HOOK="$REPO_ROOT/.claude/hooks/check-uv-install.sh"
+EDIT_HOOK="$REPO_ROOT/.claude/hooks/check-protected-files.sh"
+
+if [[ ! -x "$BASH_HOOK" ]]; then echo "FAIL: $BASH_HOOK not executable" >&2; exit 1; fi
+if [[ ! -x "$EDIT_HOOK" ]]; then echo "FAIL: $EDIT_HOOK not executable" >&2; exit 1; fi
+
+fails=0
+pass() { echo "  OK  $1"; }
+fail() { echo "  FAIL  $1" >&2; fails=$((fails + 1)); }
+
+# -----------------------------------------------------------------------------
+# Helpers — feed a JSON payload and capture (stderr, exit code).
+# -----------------------------------------------------------------------------
+
+run_bash_hook() {
+  local cmd="$1"
+  local payload
+  payload="$(jq -nc --arg cmd "$cmd" '{tool_input: {command: $cmd}}')"
+  set +e
+  out="$(printf '%s' "$payload" | bash "$BASH_HOOK" 2>&1)"
+  rc=$?
+  set -e
+}
+
+run_edit_hook() {
+  local file="$1"
+  local payload
+  payload="$(jq -nc --arg f "$file" '{tool_input: {file_path: $f}}')"
+  set +e
+  out="$(printf '%s' "$payload" | bash "$EDIT_HOOK" 2>&1)"
+  rc=$?
+  set -e
+}
+
+assert_blocked() {
+  local label="$1"
+  if [[ "$rc" -eq 2 && "$out" == *"BLOCKED"* ]]; then
+    pass "$label"
+  else
+    fail "$label (rc=$rc, out=$out)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1"
+  if [[ "$rc" -eq 0 ]]; then
+    pass "$label"
+  else
+    fail "$label (rc=$rc, out=$out)"
+  fi
+}
+
+# =============================================================================
+# Bash hook — direct forbidden commands
+# =============================================================================
+
+run_bash_hook "uv pip install httpx"
+assert_blocked "block: uv pip install"
+
+run_bash_hook "uv pip compile requirements.in"
+assert_blocked "block: uv pip compile"
+
+run_bash_hook "uv pip sync requirements.txt"
+assert_blocked "block: uv pip sync"
+
+run_bash_hook "uv pip uninstall httpx"
+assert_blocked "block: uv pip uninstall"
+
+run_bash_hook "cd apps/api && uv pip install -e ."
+assert_blocked "block: chained uv pip install"
+
+run_bash_hook "uv add httpx"
+assert_blocked "block: uv add"
+
+run_bash_hook "uv remove httpx"
+assert_blocked "block: uv remove"
+
+run_bash_hook "uv lock"
+assert_blocked "block: uv lock"
+
+run_bash_hook "uv lock --upgrade"
+assert_blocked "block: uv lock --upgrade"
+
+run_bash_hook "uvx ruff check"
+assert_blocked "block: uvx"
+
+run_bash_hook "uv tool install ruff"
+assert_blocked "block: uv tool install"
+
+run_bash_hook "uv tool run ruff"
+assert_blocked "block: uv tool run"
+
+run_bash_hook "uv tool upgrade ruff"
+assert_blocked "block: uv tool upgrade"
+
+run_bash_hook "uv sync"
+assert_blocked "block: uv sync without --frozen"
+
+run_bash_hook "uv sync --extra dev"
+assert_blocked "block: uv sync --extra dev (no --frozen)"
+
+run_bash_hook "uv sync --refresh # --frozen"
+assert_blocked "block: uv sync with --frozen as comment"
+
+run_bash_hook "FOO=--frozen uv sync"
+assert_blocked "block: env-var prefix --frozen + uv sync"
+
+run_bash_hook "uv sync --frozen-mode"
+assert_blocked "block: uv sync --frozen-mode (not standalone token)"
+
+run_bash_hook "pip install httpx"
+assert_blocked "block: pip install"
+
+run_bash_hook "pip3 install httpx"
+assert_blocked "block: pip3 install"
+
+run_bash_hook "python -m pip install httpx"
+assert_blocked "block: python -m pip install"
+
+run_bash_hook "python3 -m pip install httpx"
+assert_blocked "block: python3 -m pip install"
+
+# Backtick command substitution
+run_bash_hook 'echo `uv pip install httpx`'
+assert_blocked "block: backtick uv pip install"
+
+# =============================================================================
+# Bash hook — indirect-execution wrappers (Pattern set 2)
+# =============================================================================
+
+run_bash_hook "bash -c 'uv pip install evil'"
+assert_blocked "block: bash -c uv pip install"
+
+run_bash_hook "sh -c 'uv pip install evil'"
+assert_blocked "block: sh -c uv pip install"
+
+run_bash_hook "bash -c 'uv tool install ruff'"
+assert_blocked "block: bash -c uv tool install"
+
+run_bash_hook "bash -c 'pip install evil'"
+assert_blocked "block: bash -c pip install"
+
+run_bash_hook "bash -c 'uvx ruff'"
+assert_blocked "block: bash -c uvx"
+
+run_bash_hook "eval 'uv pip install evil'"
+assert_blocked "block: eval uv pip install"
+
+run_bash_hook 'python -c "import subprocess; subprocess.run([\"uv\",\"pip\",\"install\",\"evil\"])"'
+assert_blocked "block: python -c subprocess"
+
+run_bash_hook 'python -c "__import__('"'"'pip'"'"').main([\"install\",\"evil\"])"'
+assert_blocked "block: python -c pip __import__"
+
+# =============================================================================
+# Bash hook — file mutation against protected files (Pattern set 3)
+# =============================================================================
+
+run_bash_hook "chmod -x .claude/hooks/check-uv-install.sh"
+assert_blocked "block: chmod -x check-uv-install.sh"
+
+run_bash_hook "chmod 000 scripts/uv-install.sh"
+assert_blocked "block: chmod 000 uv-install.sh"
+
+run_bash_hook "rm scripts/uv-install.sh"
+assert_blocked "block: rm uv-install.sh"
+
+run_bash_hook "rm -f .claude/hooks/check-protected-files.sh"
+assert_blocked "block: rm -f check-protected-files.sh"
+
+run_bash_hook "mv apps/mobile/.npmrc /tmp/x"
+assert_blocked "block: mv apps/mobile/.npmrc"
+
+run_bash_hook "cp /tmp/evil scripts/install-npm-pinned.sh"
+assert_blocked "block: cp ... install-npm-pinned.sh"
+
+run_bash_hook "sed -i '' 's/exit 2/exit 0/' .claude/hooks/check-uv-install.sh"
+assert_blocked "block: sed -i check-uv-install.sh"
+
+run_bash_hook "sed --in-place 's/foo/bar/' scripts/uv-install.sh"
+assert_blocked "block: sed --in-place uv-install.sh"
+
+run_bash_hook "ln -sf /dev/null .claude/hooks/check-uv-install.sh"
+assert_blocked "block: ln -sf check-uv-install.sh"
+
+run_bash_hook "echo evil > scripts/uv-install.sh"
+assert_blocked "block: > redirect to uv-install.sh"
+
+run_bash_hook "echo evil >> apps/mobile/.npmrc"
+assert_blocked "block: >> redirect to .npmrc"
+
+run_bash_hook "tee scripts/uv-install.sh < /tmp/x"
+assert_blocked "block: tee uv-install.sh"
+
+# Read-only operations on protected files MUST still be allowed.
+run_bash_hook "cat scripts/uv-install.sh"
+assert_allowed "allow: cat uv-install.sh"
+
+run_bash_hook "grep foo scripts/uv-install.sh"
+assert_allowed "allow: grep uv-install.sh"
+
+run_bash_hook "git diff scripts/uv-install.sh"
+assert_allowed "allow: git diff uv-install.sh"
+
+# Mutation against an UNPROTECTED file in the same chain should not trigger.
+run_bash_hook "rm /tmp/scratch && cat scripts/uv-install.sh"
+assert_allowed "allow: rm /tmp + cat protected"
+
+run_bash_hook "echo done > /tmp/x && cat scripts/uv-install.sh"
+assert_allowed "allow: > /tmp + cat protected"
+
+# =============================================================================
+# Bash hook — sanctioned patterns (must remain allowed)
+# =============================================================================
+
+run_bash_hook "make api-lock"
+assert_allowed "allow: make api-lock"
+
+run_bash_hook "make api-install"
+assert_allowed "allow: make api-install"
+
+run_bash_hook "bash scripts/uv-install.sh lock"
+assert_allowed "allow: scripts/uv-install.sh lock"
+
+run_bash_hook "./scripts/install-npm-pinned.sh"
+assert_allowed "allow: scripts/install-npm-pinned.sh"
+
+run_bash_hook "uv sync --frozen"
+assert_allowed "allow: uv sync --frozen"
+
+run_bash_hook "uv sync --frozen --extra dev"
+assert_allowed "allow: uv sync --frozen --extra dev"
+
+run_bash_hook "uv sync --frozen --no-dev"
+assert_allowed "allow: uv sync --frozen --no-dev"
+
+run_bash_hook "cd apps/api && uv sync --frozen --extra dev"
+assert_allowed "allow: chained uv sync --frozen"
+
+run_bash_hook "uv sync --frozen=true"
+assert_allowed "allow: uv sync --frozen=true"
+
+run_bash_hook "uv venv"
+assert_allowed "allow: uv venv"
+
+run_bash_hook "uv run pytest"
+assert_allowed "allow: uv run pytest"
+
+run_bash_hook "uv --version"
+assert_allowed "allow: uv --version"
+
+# Unrelated commands should pass through.
+run_bash_hook "ls -la"
+assert_allowed "allow: ls"
+
+run_bash_hook "git status"
+assert_allowed "allow: git status"
+
+run_bash_hook "echo hello"
+assert_allowed "allow: echo"
+
+# Empty / non-Bash payload
+out=""
+rc=0
+set +e
+echo '{}' | bash "$BASH_HOOK" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  pass "allow: empty payload (no command)"
+else
+  fail "empty payload (rc=$rc)"
+fi
+
+# =============================================================================
+# Edit/Write/MultiEdit hook — protected files (absolute path)
+# =============================================================================
+
+run_edit_hook "/repo/apps/mobile/.npmrc"
+assert_blocked "block: edit absolute apps/mobile/.npmrc"
+
+run_edit_hook "/repo/scripts/uv-install.sh"
+assert_blocked "block: edit absolute scripts/uv-install.sh"
+
+run_edit_hook "/repo/scripts/install-npm-pinned.sh"
+assert_blocked "block: edit absolute scripts/install-npm-pinned.sh"
+
+run_edit_hook "/repo/.claude/hooks/check-uv-install.sh"
+assert_blocked "block: edit absolute check-uv-install.sh"
+
+run_edit_hook "/repo/.claude/hooks/check-protected-files.sh"
+assert_blocked "block: edit absolute check-protected-files.sh"
+
+# =============================================================================
+# Edit/Write/MultiEdit hook — protected files (relative path)
+# =============================================================================
+
+run_edit_hook "apps/mobile/.npmrc"
+assert_blocked "block: edit relative apps/mobile/.npmrc"
+
+run_edit_hook "scripts/uv-install.sh"
+assert_blocked "block: edit relative scripts/uv-install.sh"
+
+run_edit_hook ".claude/hooks/check-uv-install.sh"
+assert_blocked "block: edit relative check-uv-install.sh"
+
+# =============================================================================
+# Edit/Write/MultiEdit hook — allowed files
+# =============================================================================
+
+run_edit_hook "/repo/.claude/settings.json"
+assert_allowed "allow: edit .claude/settings.json (intentionally not protected)"
+
+run_edit_hook "/repo/apps/api/src/coyo/main.py"
+assert_allowed "allow: edit apps/api source"
+
+run_edit_hook "/repo/apps/api/uv.lock"
+assert_allowed "allow: edit uv.lock (regenerated by make api-lock)"
+
+run_edit_hook "/repo/apps/api/pyproject.toml"
+assert_allowed "allow: edit pyproject.toml"
+
+run_edit_hook "/repo/README.md"
+assert_allowed "allow: edit README.md"
+
+# Empty payload
+out=""
+rc=0
+set +e
+echo '{}' | bash "$EDIT_HOOK" >/dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  pass "allow: empty payload (no file_path)"
+else
+  fail "empty payload (rc=$rc)"
+fi
+
+# -----------------------------------------------------------------------------
+# Report
+# -----------------------------------------------------------------------------
+if (( fails > 0 )); then
+  echo "FAILED: $fails test(s)" >&2
+  exit 1
+fi
+echo "All Claude Code hook smoke tests passed."


### PR DESCRIPTION
## Summary

**PR2 of 3** in the supply-chain defense initiative. Adds two `PreToolUse` hooks for Claude Code sessions that catch **accidental** invocations which would bypass the release-age cooldown baked into `apps/api/uv.lock` and `apps/mobile/.npmrc` by [#145](https://github.com/h-aoki1623/coyo/pull/145) (PR1a) and [#149](https://github.com/h-aoki1623/coyo/pull/149) (PR1b).

These hooks are explicitly positioned as a **speed bump, not a security boundary**. Regex over a shell command string cannot understand variable expansion (`U=uv; $U pip install`), string concatenation, PATH shadowing, aliases, indirect interpreters, or "edit `.claude/settings.json` to remove the hook entries". Real enforcement lives in:

- `apps/api/uv.lock` + `uv sync --frozen` everywhere (PR1a/1b)
- `apps/mobile/.npmrc` + `engine-strict=true` (PR1b)
- The new SHA-256 integrity check on hook + wrapper scripts (this PR, verified by CI)
- Code review on `.claude/settings.json` changes

This positioning was the explicit conclusion of PR2 confirmation points 1 and 2, after both `code-reviewer` and `security-reviewer` flagged that the hook surface is fundamentally limited.

## Bash hook (`.claude/hooks/check-uv-install.sh`)

### Pattern set 1: forbidden uv subcommands
Refuses commands that resolve dependencies outside the wrapper:
- `uv pip install` / `compile` / `sync` / `uninstall`
- `uv add`, `uv remove`, `uv lock`
- `uv sync` without `--frozen` (with `--frozen` detection that handles `# --frozen` comments and `FOO=--frozen` prefix evasion)
- `uv tool install` / `run` / `upgrade`
- `uvx`
- `pip install` (`pip`, `pip3`, `python -m pip`, `python3 -m pip`)

The lead-in character class includes whitespace, `;`, `&`, `|`, `(`, and **backtick** — so `$()` and `` `…` `` substitution forms are covered.

### Pattern set 2: indirect-execution wrappers
Refuses when the inner string mentions any forbidden token:
- `bash -c '...'` / `sh -c '...'`
- `eval '...'`
- `python -c '...'` (when it touches `pip`, `subprocess`, `__import__`, `os.exec*`)

### Pattern set 3: file mutation against protected files
Refuses Bash mutations targeting any protected file, so the hook cannot be silently disabled by `chmod -x`, `rm`, `mv`, `cp`, `sed -i`, `tee`, `ln`, or `>`/`>>` redirection. **Read-only access** (`cat`, `grep`, `git diff`) on the same files is explicitly tested to remain allowed.

## Edit/Write/MultiEdit hook (`.claude/hooks/check-protected-files.sh`)

Refuses Edit/Write/MultiEdit on:
- `apps/mobile/.npmrc`
- `scripts/uv-install.sh`
- `scripts/install-npm-pinned.sh`
- `.claude/hooks/check-uv-install.sh` (self-defense)
- `.claude/hooks/check-protected-files.sh` (self-defense)

Resolves symlinks via `os.path.realpath` before matching, and accepts both absolute and relative paths so `Edit apps/mobile/.npmrc` (relative) is also blocked.

`.claude/settings.json` is **intentionally NOT protected** per the project decision recorded in PR2 confirmation point 5.

## Fail-closed posture

Both hooks require `jq` and exit 2 if it is missing or the JSON is malformed. A missing-jq fail-open would defeat the entire purpose.

## CI integrity check

`.security/hook-hashes.sha256` pins the SHA-256 of:
- both hooks
- `scripts/uv-install.sh`
- `scripts/install-npm-pinned.sh`
- both smoke test scripts

A new `hook-integrity` CI job runs `sha256sum -c` on every PR. Workflow `paths:` filter was removed so `wrapper-tests`, `hook-tests`, and `hook-integrity` fire even on PRs that touch unrelated code.

## Smoke tests

`scripts/test/test-claude-hooks.sh` covers **78 cases**:
- direct forbidden patterns (uv pip install, uv tool, uvx, etc.)
- indirect-execution wrappers (bash -c, eval, python -c)
- file mutation against protected files (chmod, rm, sed -i, ln, > redirection)
- read-only access to protected files (cat, grep, git diff) MUST stay allowed
- sanctioned entry points (make api-lock, make api-install, etc.) MUST stay allowed
- Edit hook absolute + relative path coverage
- empty / non-Bash payload handling

## Known limitations (intentional, documented in `docs/CONTRIB.md`)

- Variable expansion (`U=uv; $U pip install`) NOT caught
- String concatenation (`"u""v" pip install`) NOT caught
- PATH-shadowing / aliases NOT caught
- `.claude/settings.json` edits NOT caught (intentional per confirmation point 5)

These were assessed in PR2 confirmation points 1 and 2 and deliberately left out of scope. PR1a/1b's lockfile + `--frozen` chain remains the authoritative supply-chain control.

## Review findings addressed

Both `code-reviewer` and `security-reviewer` reviewed an earlier revision of this change. All Critical/High/Major findings within the agreed scope were addressed:

| Finding | Source | Status |
|---|---|---|
| H1: `uv sync --frozen` regex tightening (standalone token, comment removal, env-var prefix denial) | security | ✅ |
| H2: `uvx`, `uv tool install/run/upgrade` blocks | security | ✅ |
| H3: Bash file mutation against protected files | security | ✅ |
| H4: Fail-closed on jq missing / malformed JSON | security | ✅ |
| H5: Backtick in lead-in character class | security | ✅ |
| H6: Symlink resolution + relative path matching in Edit hook | security | ✅ |
| M1: Disable snippet removed from error messages, moved to docs | security | ✅ |
| M3: CI SHA-256 hash integrity check on all hook + wrapper scripts | security | ✅ |
| M4: `paths:` filter removed so hook tests run on every PR | security | ✅ |
| M5: `uv pip compile` / `sync` / `uninstall` blocks | security | ✅ |
| X1-X3: `bash -c` / `sh -c` / `eval` / `python -c` indirect-execution blocks | confirmation point 2 | ✅ |
| Adversarial test cases for all of the above | code | ✅ (78 cases) |
| Speed bump positioning in docs and hook docstrings | both | ✅ |

The C1 (protect `.claude/settings.json`) finding was reviewed against confirmation point 5 and deliberately not adopted. C2 (indirect execution bypasses) is acknowledged as a fundamental limitation of regex-based hooks.

## Verification

- [x] `bash -n` syntax check on both hooks and the test script
- [x] `python -c "import json; ..."` on `settings.json`
- [x] `python -c "import yaml; ..."` on `ci.yml`
- [x] `sha256sum -c .security/hook-hashes.sha256` (all 6 files match)
- [x] `bash scripts/test/test-claude-hooks.sh` (78/78 pass)
- [x] `bash scripts/test/test-uv-install.sh` (6/6 pass — unchanged from PR1b)

## Reviewer notes

- E2E tests are intentionally skipped — this PR only touches Claude Code agent tooling and CI; no user-visible behaviour change.
- No Cloud Run deploy verification needed — `Dockerfile`, `deploy-api.yml`, and any production code paths are untouched.
- After merge, when bumping the pinned npm version or updating the wrapper for a new uv release, follow the 5-step procedure documented in `docs/CONTRIB.md` "Updating a protected file legitimately" (disable hook locally → edit → re-run smoke tests → regenerate hashes → revert local override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)