### PR TITLE
fix(mobile): show home suggestions on first cold-start launch

### DIFF
--- a/apps/mobile/e2e/home-topic-cards.yaml
+++ b/apps/mobile/e2e/home-topic-cards.yaml
@@ -22,24 +22,36 @@ appId: to.coyo.app
       id: "home-greeting"
     timeout: 30000
 
-# Scroll to topic cards (suggestions may push them below the fold)
-# Scroll down to reveal topic cards (avoid sign-out button at bottom)
-- swipe:
-    start: "50%, 60%"
-    end: "50%, 30%"
-    duration: 500
-
-# Verify all 5 topic cards are visible via testID
-- assertVisible:
-    id: "topic-sports"
-- assertVisible:
-    id: "topic-business"
-- assertVisible:
-    id: "topic-politics"
-- assertVisible:
-    id: "topic-technology"
-- assertVisible:
-    id: "topic-entertainment"
+# Scroll to each topic card. With personalized + trending suggestions
+# now reliably populated above the fold, the fixed topic cards are pushed
+# further down — sometimes the entire viewport. A fixed-distance swipe is
+# brittle here, so we use scrollUntilVisible to walk through every card
+# regardless of how tall the suggestions section happens to be.
+- scrollUntilVisible:
+    element:
+      id: "topic-sports"
+    direction: DOWN
+    speed: 40
+- scrollUntilVisible:
+    element:
+      id: "topic-business"
+    direction: DOWN
+    speed: 40
+- scrollUntilVisible:
+    element:
+      id: "topic-politics"
+    direction: DOWN
+    speed: 40
+- scrollUntilVisible:
+    element:
+      id: "topic-technology"
+    direction: DOWN
+    speed: 40
+- scrollUntilVisible:
+    element:
+      id: "topic-entertainment"
+    direction: DOWN
+    speed: 40
 
 # Verify the history button is present via testID
 - assertVisible:

--- a/apps/mobile/e2e/voice-conversation.yaml
+++ b/apps/mobile/e2e/voice-conversation.yaml
@@ -30,17 +30,14 @@ appId: to.coyo.app
       id: "home-greeting"
     timeout: 30000
 
-# Scroll to the Sports topic card (may be below the fold when suggestions are shown)
-# Scroll down to reveal topic cards (avoid sign-out button at bottom)
-- swipe:
-    start: "50%, 60%"
-    end: "50%, 30%"
-    duration: 500
-
-- extendedWaitUntil:
-    visible:
+# Scroll to the Sports topic card. With suggestions now reliably populated
+# above the fold (see suggestions-store.ts), Sports may be pushed further
+# down — use scrollUntilVisible instead of a fixed swipe distance.
+- scrollUntilVisible:
+    element:
       id: "topic-sports"
-    timeout: 5000
+    direction: DOWN
+    speed: 40
 
 - tapOn:
     id: "topic-sports"

--- a/apps/mobile/src/features/home/hooks/__tests__/useSuggestions.test.ts
+++ b/apps/mobile/src/features/home/hooks/__tests__/useSuggestions.test.ts
@@ -90,4 +90,31 @@ describe('useSuggestions', () => {
 
     expect(mockGet).toHaveBeenCalledTimes(1);
   });
+
+  it('retries when HomeScreen mounts after a failed first-launch prefetch', async () => {
+    // Simulate the production bug: on cold start, the prefetch kicked off
+    // from auth-store fails (e.g., Firebase token not yet warm, or
+    // /api/auth/session hasn't created the backend user row yet, so
+    // /api/topics/suggestions 401s).
+    mockGet.mockRejectedValueOnce(new Error('401 Unauthorized'));
+    await useSuggestionsStore.getState().prefetch();
+
+    // Sanity check: the failed prefetch left the store empty.
+    expect(useSuggestionsStore.getState().suggestions).toEqual({
+      personal: [],
+      trending: [],
+    });
+
+    // Now the HomeScreen mounts. The hook MUST trigger a retry and populate
+    // the store — not sit on the empty state forever because `isReady`
+    // flipped to true on the failed attempt.
+    mockGet.mockResolvedValueOnce({ data: mockResponse });
+
+    const { result } = renderHook(() => useSuggestions());
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual(mockResponse);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/mobile/src/features/home/hooks/useSuggestions.ts
+++ b/apps/mobile/src/features/home/hooks/useSuggestions.ts
@@ -5,19 +5,33 @@ import { useSuggestionsStore } from '@/stores/suggestions-store';
 /**
  * Reads cached topic suggestions from the store. The store is normally
  * primed by `auth-store.initialize()` immediately after sign-in, so by the
- * time HomeScreen mounts the data is already available. If for any reason
- * the cache is empty (e.g., a hot reload), this hook triggers a fetch.
+ * time HomeScreen mounts the data is already available.
+ *
+ * If the cache is empty because the prefetch hasn't run yet (hot reload) or
+ * because it ran but failed (cold-start auth race where the Firebase token
+ * or backend user row wasn't ready), this hook triggers a single retry on
+ * mount. We gate on `hasLoaded` rather than `isReady` so a failed first
+ * attempt does not lock the user into an empty Home until a full app
+ * restart. The retry fires at most once per hook instance so a persistently
+ * failing API can't hammer the backend — a subsequent retry requires the
+ * user to remount the screen (navigate away and back).
  */
 export function useSuggestions() {
   const suggestions = useSuggestionsStore((s) => s.suggestions);
-  const isReady = useSuggestionsStore((s) => s.isReady);
+  const hasLoaded = useSuggestionsStore((s) => s.hasLoaded);
   const isLoading = useSuggestionsStore((s) => s.isLoading);
 
   useEffect(() => {
-    if (!isReady && !isLoading) {
-      useSuggestionsStore.getState().prefetch();
+    // Read the store directly (not the subscribed values) so this effect
+    // runs exactly once per mount regardless of state changes while we wait.
+    // The empty dep array is intentional: re-running on state changes would
+    // create an infinite retry loop against a persistently failing backend.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const state = useSuggestionsStore.getState();
+    if (!state.hasLoaded && !state.isLoading) {
+      state.prefetch();
     }
-  }, [isReady, isLoading]);
+  }, []);
 
-  return { suggestions, isLoading: isLoading && !isReady };
+  return { suggestions, isLoading: isLoading && !hasLoaded };
 }

--- a/apps/mobile/src/features/home/hooks/useSuggestions.ts
+++ b/apps/mobile/src/features/home/hooks/useSuggestions.ts
@@ -26,7 +26,6 @@ export function useSuggestions() {
     // runs exactly once per mount regardless of state changes while we wait.
     // The empty dep array is intentional: re-running on state changes would
     // create an infinite retry loop against a persistently failing backend.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const state = useSuggestionsStore.getState();
     if (!state.hasLoaded && !state.isLoading) {
       state.prefetch();

--- a/apps/mobile/src/stores/auth-store.test.ts
+++ b/apps/mobile/src/stores/auth-store.test.ts
@@ -16,6 +16,30 @@ jest.mock('@/services/firebase-auth', () => ({
   getIdToken: jest.fn(),
 }));
 
+// Mock api client so we can assert request ordering during initialize().
+const mockApiPost = jest.fn();
+jest.mock('@/api/client', () => ({
+  apiClient: {
+    post: (...args: unknown[]) => mockApiPost(...args),
+    get: jest.fn(),
+    delete: jest.fn(),
+    postStream: jest.fn(),
+  },
+}));
+
+// Mock suggestions store so we can assert prefetch ordering relative to
+// the session-sync POST.
+const mockSuggestionsPrefetch = jest.fn();
+const mockSuggestionsReset = jest.fn();
+jest.mock('@/stores/suggestions-store', () => ({
+  useSuggestionsStore: {
+    getState: () => ({
+      prefetch: mockSuggestionsPrefetch,
+      reset: mockSuggestionsReset,
+    }),
+  },
+}));
+
 import {
   configureGoogleSignIn,
   onAuthStateChanged,
@@ -72,6 +96,11 @@ describe('useAuthStore', () => {
   beforeEach(() => {
     resetStore();
     jest.clearAllMocks();
+    // Default: session sync resolves immediately so initialize() and
+    // sign-up flows don't block. Tests that care about timing override
+    // this with their own implementation.
+    mockApiPost.mockResolvedValue({ data: null });
+    mockSuggestionsPrefetch.mockResolvedValue(undefined);
   });
 
   describe('initial state', () => {
@@ -169,6 +198,77 @@ describe('useAuthStore', () => {
       await Promise.resolve();
 
       expect(useAuthStore.getState().isEmailVerified).toBe(false);
+    });
+
+    it('awaits /api/auth/session before kicking off the suggestions prefetch', async () => {
+      // Regression guard for the first-launch empty-Home bug. Firing the
+      // suggestions prefetch in parallel with the session-sync POST caused
+      // a new user's /api/topics/suggestions request to hit the backend
+      // before the user row was committed, returning empty. This test
+      // locks in the ordering fix in auth-store.initialize().
+      const callOrder: string[] = [];
+      let resolveSession: () => void = () => {};
+      mockApiPost.mockImplementation((path: string) => {
+        callOrder.push(`post:${path}`);
+        return new Promise<{ data: unknown }>((resolve) => {
+          resolveSession = () => resolve({ data: null });
+        });
+      });
+      mockSuggestionsPrefetch.mockImplementation(() => {
+        callOrder.push('prefetch');
+        return Promise.resolve();
+      });
+
+      const mockUser = createMockUser({ emailVerified: true });
+      mockOnAuthStateChanged.mockImplementation((callback) => {
+        callback(mockUser);
+        return jest.fn();
+      });
+      useAuthStore.getState().initialize();
+
+      // After initialize(), only the session POST should be observed —
+      // prefetch must NOT have been called yet because session hasn't
+      // resolved.
+      await Promise.resolve();
+      expect(callOrder).toEqual(['post:/api/auth/session']);
+      expect(mockSuggestionsPrefetch).not.toHaveBeenCalled();
+
+      // Resolve the session sync; the prefetch should now fire.
+      resolveSession();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(callOrder).toEqual(['post:/api/auth/session', 'prefetch']);
+      expect(mockSuggestionsPrefetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips prefetch if the user signed out while session sync was in flight', async () => {
+      // Defensive guard: if the user taps Sign Out during the `await`, the
+      // isAuthenticated flag flips back to false via a second callback.
+      // The first callback must NOT kick off a prefetch for a signed-out
+      // user after its await resolves.
+      let resolveSession: () => void = () => {};
+      mockApiPost.mockImplementation(
+        () =>
+          new Promise<{ data: unknown }>((resolve) => {
+            resolveSession = () => resolve({ data: null });
+          }),
+      );
+
+      const mockUser = createMockUser({ emailVerified: true });
+      mockOnAuthStateChanged.mockImplementation((callback) => {
+        callback(mockUser);
+        return jest.fn();
+      });
+      useAuthStore.getState().initialize();
+      await Promise.resolve();
+
+      // Simulate sign-out landing on the store before session resolves.
+      useAuthStore.setState({ isAuthenticated: false, user: null });
+
+      resolveSession();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockSuggestionsPrefetch).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -74,16 +74,29 @@ export const useAuthStore = create<AuthState>((set, _get) => ({
           isInitialized: true,
           isLoading: false,
         });
-        // Create/sync backend user record immediately after auth (non-blocking)
-        apiClient.post('/api/auth/session').catch(() => {
-          // Session sync failure is non-critical; get_current_user will
-          // create the record lazily on the next API call as a fallback.
-        });
+        // Create/sync backend user record FIRST, then prefetch suggestions.
+        // Ordering matters: /api/topics/suggestions requires the backend
+        // user row to exist, and on a brand-new sign-up the two requests
+        // would otherwise race to INSERT the same user concurrently — one
+        // side rolls back with IntegrityError and the suggestions query
+        // could land before the row is committed, coming back empty.
+        // Awaiting session sync serializes them. Session errors are
+        // non-critical (get_current_user creates the row lazily as a
+        // fallback), so we swallow them and continue to prefetch.
+        await apiClient.post('/api/auth/session').catch(() => {});
+        // If the user signed out during the session-sync await, bail out.
+        // The sign-out path of onAuthStateChanged will run `reset()` and
+        // bump the generation token separately, but kicking off a prefetch
+        // for a just-signed-out user is wasted work at best and could race
+        // with the sign-out state reset at worst.
+        if (!useAuthStore.getState().isAuthenticated) {
+          return;
+        }
         // Prefetch home suggestions so the Home screen has data ready by
         // the time the user lands on it. The splash screen waits on this
-        // promise (capped at SPLASH_PREFETCH_TIMEOUT_MS in `useSplashGate`)
-        // so users see a fully-populated Home rather than an empty Home
-        // that pops in suggestions a moment later. Defensive .catch in case
+        // promise (capped at SPLASH_PREFETCH_TIMEOUT_MS in App.tsx) so
+        // users see a fully-populated Home rather than an empty Home that
+        // pops in suggestions a moment later. Defensive .catch in case
         // prefetch is ever refactored to reject.
         useSuggestionsStore.getState().prefetch().catch(() => {});
       } else {

--- a/apps/mobile/src/stores/suggestions-store.test.ts
+++ b/apps/mobile/src/stores/suggestions-store.test.ts
@@ -42,6 +42,7 @@ describe('useSuggestionsStore', () => {
       const state = useSuggestionsStore.getState();
       expect(state.suggestions).toEqual({ personal: [], trending: [] });
       expect(state.isReady).toBe(false);
+      expect(state.hasLoaded).toBe(false);
       expect(state.isLoading).toBe(false);
     });
   });
@@ -56,21 +57,26 @@ describe('useSuggestionsStore', () => {
       const state = useSuggestionsStore.getState();
       expect(state.suggestions).toEqual(sampleResponse);
       expect(state.isReady).toBe(true);
+      expect(state.hasLoaded).toBe(true);
       expect(state.isLoading).toBe(false);
     });
 
-    it('marks as ready even when fetch fails', async () => {
+    it('marks as ready but NOT loaded when fetch fails (so the hook can retry)', async () => {
       mockGet.mockRejectedValue(new Error('network'));
 
       await useSuggestionsStore.getState().prefetch();
 
       const state = useSuggestionsStore.getState();
       expect(state.suggestions).toEqual({ personal: [], trending: [] });
+      // isReady flips so the splash gate can release — we never want to
+      // strand the user on the splash because the API is down.
       expect(state.isReady).toBe(true);
+      // hasLoaded stays false so `useSuggestions` retries on mount.
+      expect(state.hasLoaded).toBe(false);
       expect(state.isLoading).toBe(false);
     });
 
-    it('marks as ready when API returns an error envelope (no data)', async () => {
+    it('marks as ready but NOT loaded when API returns an error envelope (no data)', async () => {
       mockGet.mockResolvedValue({
         error: { code: 'INTERNAL_ERROR', message: 'oops' },
       });
@@ -80,6 +86,23 @@ describe('useSuggestionsStore', () => {
       const state = useSuggestionsStore.getState();
       expect(state.suggestions).toEqual({ personal: [], trending: [] });
       expect(state.isReady).toBe(true);
+      expect(state.hasLoaded).toBe(false);
+    });
+
+    it('preserves hasLoaded and cached data across a subsequent failing refetch', async () => {
+      // First call succeeds and populates the cache.
+      mockGet.mockResolvedValueOnce({ data: sampleResponse });
+      await useSuggestionsStore.getState().prefetch();
+      expect(useSuggestionsStore.getState().hasLoaded).toBe(true);
+
+      // A later refetch failure must NOT invalidate the previously loaded
+      // cache — users should continue to see the data they already had.
+      mockGet.mockRejectedValueOnce(new Error('network'));
+      await useSuggestionsStore.getState().prefetch();
+
+      const state = useSuggestionsStore.getState();
+      expect(state.suggestions).toEqual(sampleResponse);
+      expect(state.hasLoaded).toBe(true);
     });
 
     it('reuses an in-flight request instead of firing twice', async () => {
@@ -111,6 +134,7 @@ describe('useSuggestionsStore', () => {
       const state = useSuggestionsStore.getState();
       expect(state.suggestions).toEqual({ personal: [], trending: [] });
       expect(state.isReady).toBe(false);
+      expect(state.hasLoaded).toBe(false);
       expect(state.isLoading).toBe(false);
     });
 

--- a/apps/mobile/src/stores/suggestions-store.ts
+++ b/apps/mobile/src/stores/suggestions-store.ts
@@ -16,8 +16,22 @@ const EMPTY_RESPONSE: TopicSuggestionsResponse = { personal: [], trending: [] };
 
 interface SuggestionsState {
   suggestions: TopicSuggestionsResponse;
-  /** True once the first prefetch (success or failure) has settled. */
+  /**
+   * True once the first prefetch attempt (success OR failure) has settled.
+   * Used by the splash gate to decide when to hide the native splash — it
+   * intentionally does NOT distinguish success from failure so a failing
+   * API never strands the user on the splash screen.
+   */
   isReady: boolean;
+  /**
+   * True once a prefetch has successfully populated `suggestions`. Used by
+   * `useSuggestions` to decide whether to retry on HomeScreen mount. Without
+   * this, a failed first-launch prefetch (e.g., cold-start race where the
+   * Firebase token or backend user row isn't ready yet) would flip
+   * `isReady=true` and the hook would never retry, leaving the user with an
+   * empty Home until a full app restart.
+   */
+  hasLoaded: boolean;
   /** True while a fetch is in flight. */
   isLoading: boolean;
 
@@ -40,6 +54,7 @@ let generation = 0;
 export const useSuggestionsStore = create<SuggestionsState>((set) => ({
   suggestions: EMPTY_RESPONSE,
   isReady: false,
+  hasLoaded: false,
   isLoading: false,
 
   prefetch: () => {
@@ -49,6 +64,7 @@ export const useSuggestionsStore = create<SuggestionsState>((set) => ({
     set({ isLoading: true });
 
     inflight = (async () => {
+      let succeeded = false;
       try {
         const result = await apiClient.get<TopicSuggestionsResponse>(
           '/api/topics/suggestions',
@@ -58,15 +74,25 @@ export const useSuggestionsStore = create<SuggestionsState>((set) => ({
         if (myGeneration !== generation) return;
         if (result.data) {
           set({ suggestions: result.data });
+          succeeded = true;
         }
-        // HTTP error envelopes (result.error) are intentionally ignored:
-        // suggestions are an optional enhancement and Home falls back to
-        // its fixed topic cards. We do not surface them to the user here.
+        // HTTP error envelopes (result.error) are intentionally not surfaced:
+        // suggestions are an optional enhancement and Home falls back to its
+        // fixed topic cards. But we DO track success separately via
+        // `hasLoaded` so that `useSuggestions` can retry on HomeScreen mount
+        // after a transient failure (e.g., the cold-start auth race).
       } catch {
-        // Network / parse error — same fallback as the error envelope path.
+        // Network / parse error — same handling as the error envelope path.
       } finally {
         if (myGeneration === generation) {
-          set({ isReady: true, isLoading: false });
+          set((state) => ({
+            isReady: true,
+            isLoading: false,
+            // Only flip hasLoaded to true on a successful fetch. Once true,
+            // leave it true — a later failing refetch must not invalidate
+            // previously cached data.
+            hasLoaded: succeeded || state.hasLoaded,
+          }));
         }
         inflight = null;
       }
@@ -79,6 +105,11 @@ export const useSuggestionsStore = create<SuggestionsState>((set) => ({
     // it eventually resolves — preventing cross-user cache leakage.
     generation += 1;
     inflight = null;
-    set({ suggestions: EMPTY_RESPONSE, isReady: false, isLoading: false });
+    set({
+      suggestions: EMPTY_RESPONSE,
+      isReady: false,
+      hasLoaded: false,
+      isLoading: false,
+    });
   },
 }));


### PR DESCRIPTION
## Summary

Fixes the production bug where the Home screen's recommended topics section was empty on the very first cold-start launch and only populated from the second launch onward. The store is **not** persisted, so the apparent "cache hit" on later launches was actually two latent bugs masking each other.

### Root cause

1. **Cold-start race in `auth-store.initialize`** — `/api/auth/session` and `/api/topics/suggestions` were fired in parallel from `onAuthStateChanged`. On a brand-new sign-up, both requests called `find_or_create_by_auth_uid` concurrently — one side rolled back with `IntegrityError` and the suggestions query could land before the user row was committed, returning an empty list.
2. **Failed-prefetch lockout in `suggestions-store.prefetch`** — regardless of why the fetch came back empty, the `finally` block flipped `isReady=true`. `useSuggestions` gated retries on `isReady`, so a single failed prefetch trapped Home in the empty state until a full app restart.

### Fix

- **`auth-store.ts`** — `await` the `/api/auth/session` POST before kicking off `prefetch()`, serializing the user-row INSERT. Bail out if the user signed out during the await.
- **`suggestions-store.ts`** — introduce a separate `hasLoaded` success flag. `isReady` keeps its splash-gate semantics (settles on success OR failure so the splash always releases), while `hasLoaded` only flips true on a successful fetch and is preserved across subsequent failing refetches so cached data is never invalidated by a transient error.
- **`useSuggestions.ts`** — gate the mount-time retry on `hasLoaded` (not `isReady`) and read store state directly inside an empty-deps `useEffect` so the retry fires exactly once per mount, never hammering a degraded backend.

### E2E flow updates

`home-topic-cards.yaml` and `voice-conversation.yaml` previously used fixed-distance swipes that implicitly assumed suggestions did **not** populate above the fold (the bug condition!). With suggestions now reliably rendered, the fixed topic cards are pushed further down. Switched to `scrollUntilVisible` so the flows tolerate any suggestions section height. Visual confirmation from the failing E2E run actually verified the fix is working — the screenshot showed three live trending suggestions ("Blizzard 2026", "NASA's Artemis II", "India Wins Men's T20 World Cup") rendering above the fixed cards, which is exactly the regression we wanted to see.

## Test plan

- [x] `npx jest` — 310/310 unit tests pass (added 4 new regression tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx expo export` — succeeds
- [x] New regression test in `useSuggestions.test.ts`: failed first prefetch + HomeScreen mount → store populates
- [x] New ordering test in `auth-store.test.ts`: session POST is awaited before prefetch
- [x] New defensive test in `auth-store.test.ts`: prefetch is skipped if user signed out during the session-sync await
- [x] New `suggestions-store.test.ts` test: `hasLoaded` survives a subsequent failing refetch (cached data not invalidated)
- [ ] Maestro E2E on iOS Simulator (`make e2e-ios`) — needs re-run after `scrollUntilVisible` update
- [ ] Maestro E2E on Android Emulator (`make e2e-android`) — needs re-run after `scrollUntilVisible` update
- [ ] Manual smoke test on a freshly-installed dev build (cold start with brand-new Firebase user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)