### PR TITLE
fix(mobile): wire eas-build-pre-install hook into package.json

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/",
     "test": "jest",
     "typecheck": "tsc --noEmit",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "eas-build-pre-install": "bash ./eas-build-pre-install.sh"
   },
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",


### PR DESCRIPTION
## Summary

- EAS iOS builds were failing with `EBADENGINE` because the `eas-build-pre-install` npm script entry was missing from `apps/mobile/package.json`, so EAS never ran `apps/mobile/eas-build-pre-install.sh` and `npm` stayed at the worker default (10.8.2).
- With `engine-strict=true` in `.npmrc` and `engines.npm: ">=11.10.0"` in `package.json` (both added in #f97b210 for the supply-chain release-age cooldown), `npm install` fails immediately on worker npm 10.8.2.
- This PR adds the single missing script entry so EAS executes the hook, which installs the pinned, integrity-verified npm@11.10.0 before `npm ci` runs. The cooldown (`min-release-age=7`) and engine floor are now actually enforced on EAS, matching what CI already does via `scripts/install-npm-pinned.sh`.

## Failure log (before fix)

```
Running "npm install --include=dev" in /Users/expo/workingdir/build/apps/mobile directory
npm error code EBADENGINE
npm error notsup Required: {"npm":">=11.10.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.18.3"}
Build failed
```

## Test plan

- [ ] `eas build -p ios --profile development` completes dependency install
- [ ] Build log shows `[install-npm-pinned] npm 11.10.0 ready` before `npm install`
- [ ] `eas build -p android --profile development` still succeeds (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)