### PR TITLE
fix(mobile): pin EAS Build Node to 22.13.0

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,6 +7,7 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "node": "22.13.0",
       "env": {
         "APP_ENV": "development",
         "API_BASE_URL": "http://localhost:8000"
@@ -17,6 +18,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "node": "22.13.0",
       "env": {
         "APP_ENV": "production",
         "API_BASE_URL": "https://coyo-api-1008709417218.asia-northeast1.run.app",
@@ -29,6 +31,7 @@
     },
     "production": {
       "autoIncrement": true,
+      "node": "22.13.0",
       "env": {
         "APP_ENV": "production",
         "API_BASE_URL": "https://coyo-api-1008709417218.asia-northeast1.run.app",


### PR DESCRIPTION
## Summary

- Follow-up to #154. With the pre-install hook now actually running, EAS workers run \`npm ci\` on npm 11.10.0 and \`engine-strict=true\` is finally enforced. The transitive dev dep \`eslint-visitor-keys@5.0.0\` requires Node \`^20.19.0 || ^22.13.0 || >=24\`, but EAS workers default to \`v20.18.3\`, so the install fails with \`EBADENGINE\`.
- Pin \`node\` to \`22.13.0\` (LTS Jod) in all three build profiles so EAS uses a deterministic Node image that satisfies the engine floor.

## Failure log (before fix)

\`\`\`
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: eslint-visitor-keys@5.0.0
npm error notsup Required: {"node":"^20.19.0 || ^22.13.0 || >=24"}
npm error notsup Actual:   {"node":"v20.18.3","npm":"11.10.0"}
\`\`\`

## Test plan

- [ ] \`npx eas build --platform ios --profile preview\` reaches the end of the Install dependencies phase
- [ ] Build log shows Node 22.13.0 selected and \`[install-npm-pinned] npm 11.10.0 ready\` before \`npm install\`
- [ ] \`npx eas build --platform android --profile preview\` also succeeds

## Notes

Node is pinned per-profile (duplicated three times). If we grow more profiles, consider refactoring with an \`extends\` base profile to DRY the shared config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)