### PR TITLE
fix(mobile): retry home suggestions when prefetch settles after HomeScreen mounts

### DIFF
--- a/apps/mobile/src/features/home/hooks/__tests__/useSuggestions.test.ts
+++ b/apps/mobile/src/features/home/hooks/__tests__/useSuggestions.test.ts
@@ -36,7 +36,10 @@ const mockResponse: TopicSuggestionsResponse = {
 
 describe('useSuggestions', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    // Use mockReset (not clearAllMocks) so queued mockResolvedValueOnce /
+    // mockRejectedValueOnce implementations from a prior test that timed
+    // out cannot leak into the next test.
+    mockGet.mockReset();
     useSuggestionsStore.getState().reset();
   });
 
@@ -116,5 +119,66 @@ describe('useSuggestions', () => {
       expect(result.current.suggestions).toEqual(mockResponse);
     });
     expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when HomeScreen mounts DURING an inflight prefetch that later fails', async () => {
+    // Production regression: on a slow cold-start, App.tsx's splash gate
+    // releases (either because SPLASH_PREFETCH_TIMEOUT_MS fires or
+    // because `isReady` flipped to true) while auth-store's prefetch is
+    // still in flight. HomeScreen mounts, the hook sees isLoading=true
+    // and skips the retry. The inflight prefetch then resolves as a
+    // failure (empty/401/etc.). The hook MUST detect the transition
+    // from loading→failed and retry exactly once — it must NOT sit on
+    // the empty state until the user kills and relaunches the app.
+    let failFirstPrefetch: (err: Error) => void = () => {};
+    mockGet.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          failFirstPrefetch = reject;
+        }),
+    );
+
+    // Kick off the initial prefetch (mirrors auth-store.initialize).
+    // Do NOT await — the test point is that HomeScreen mounts WHILE
+    // the request is still in flight.
+    const initialPrefetch = useSuggestionsStore.getState().prefetch();
+    expect(useSuggestionsStore.getState().isLoading).toBe(true);
+
+    // HomeScreen mounts with isLoading=true. The hook must not retry
+    // yet, but it must arm itself to retry once the inflight settles.
+    const { result } = renderHook(() => useSuggestions());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    // Now the inflight prefetch fails. The next call should succeed.
+    mockGet.mockResolvedValueOnce({ data: mockResponse });
+    failFirstPrefetch(new Error('401 Unauthorized'));
+    await initialPrefetch;
+
+    // The hook must observe isLoading→false while hasLoaded is still
+    // false, and trigger exactly one retry.
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual(mockResponse);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry more than once per mount when the retry itself fails', async () => {
+    // Bound the retry: even if the retry fails too, the hook must
+    // stop — a persistently failing backend must not be hammered on
+    // every state transition.
+    mockGet.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useSuggestions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Give the effect plenty of time to (incorrectly) fire another retry.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Exactly one call from the hook's mount-time fetch. No retry storm.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(result.current.suggestions).toEqual({ personal: [], trending: [] });
   });
 });

--- a/apps/mobile/src/features/home/hooks/useSuggestions.ts
+++ b/apps/mobile/src/features/home/hooks/useSuggestions.ts
@@ -1,36 +1,45 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useSuggestionsStore } from '@/stores/suggestions-store';
 
 /**
  * Reads cached topic suggestions from the store. The store is normally
- * primed by `auth-store.initialize()` immediately after sign-in, so by the
- * time HomeScreen mounts the data is already available.
+ * primed by `auth-store.initialize()` immediately after sign-in, so by
+ * the time HomeScreen mounts the data is already available.
  *
- * If the cache is empty because the prefetch hasn't run yet (hot reload) or
- * because it ran but failed (cold-start auth race where the Firebase token
- * or backend user row wasn't ready), this hook triggers a single retry on
- * mount. We gate on `hasLoaded` rather than `isReady` so a failed first
- * attempt does not lock the user into an empty Home until a full app
- * restart. The retry fires at most once per hook instance so a persistently
- * failing API can't hammer the backend — a subsequent retry requires the
- * user to remount the screen (navigate away and back).
+ * If the cache is empty because the prefetch hasn't run yet (hot reload)
+ * or because it failed (cold-start auth race, stale Firebase token, etc.),
+ * this hook triggers a retry — at most once per hook instance, to bound
+ * network traffic against a persistently failing backend.
+ *
+ * The effect depends on both `hasLoaded` and `isLoading` so that it can
+ * react to the transition `isLoading=true → false` that happens when the
+ * initial auth-store prefetch settles AFTER HomeScreen has already
+ * mounted. The previous (empty-deps) implementation had a latent bug:
+ * when App.tsx's splash gate released while the initial prefetch was
+ * still in flight (either because `isReady` had flipped or because
+ * `SPLASH_PREFETCH_TIMEOUT_MS` fired), HomeScreen would mount with
+ * `isLoading=true`, the effect would skip, and the effect would never
+ * run again — locking the user into an empty Home until a full app
+ * restart. This was the original "suggestions don't show on first
+ * launch" production bug.
  */
 export function useSuggestions() {
   const suggestions = useSuggestionsStore((s) => s.suggestions);
   const hasLoaded = useSuggestionsStore((s) => s.hasLoaded);
   const isLoading = useSuggestionsStore((s) => s.isLoading);
 
+  // Guard against retry storms: a persistently failing backend would
+  // otherwise re-trigger the effect on every `isLoading` transition.
+  const didRetryRef = useRef(false);
+
   useEffect(() => {
-    // Read the store directly (not the subscribed values) so this effect
-    // runs exactly once per mount regardless of state changes while we wait.
-    // The empty dep array is intentional: re-running on state changes would
-    // create an infinite retry loop against a persistently failing backend.
-    const state = useSuggestionsStore.getState();
-    if (!state.hasLoaded && !state.isLoading) {
-      state.prefetch();
-    }
-  }, []);
+    if (didRetryRef.current) return;
+    if (hasLoaded) return;
+    if (isLoading) return;
+    didRetryRef.current = true;
+    useSuggestionsStore.getState().prefetch();
+  }, [hasLoaded, isLoading]);
 
   return { suggestions, isLoading: isLoading && !hasLoaded };
 }


### PR DESCRIPTION
## Summary

Follow-up to #152. That PR landed in production but the original bug (Home screen shows no recommended topics on first cold-start launch) **still reproduced** after deploy. My previous fix contained a latent issue in `useSuggestions.ts` that this PR addresses.

### What #152 missed

The `useEffect` in `useSuggestions.ts` had an empty dep array `[]` with a comment rationalizing it as "run once per mount to avoid retry storms". That missed the critical race:

1. Auth-store fires `prefetch()` → store transitions to `isLoading=true`
2. App.tsx's splash gate releases (either because `isReady` already flipped or because `SPLASH_PREFETCH_TIMEOUT_MS = 2500ms` fires) → HomeScreen mounts
3. The hook's effect runs **once**, sees `isLoading=true`, skips the retry
4. The inflight prefetch later resolves as a **failure** (stale Firebase ID token on cold start, 401, etc.) → store transitions to `hasLoaded=false, isLoading=false`
5. The effect never re-runs due to empty deps → **no retry** → Home is stuck empty until full app restart

This matches the reported production behavior exactly. On a 2nd launch Firebase has its token warm on disk, the initial prefetch succeeds, and everything works — which is why the user initially guessed "cache".

### Fix

- **Effect deps** → `[hasLoaded, isLoading]` so the hook reacts to the `isLoading: true → false` transition that happens when the initial auth-store prefetch settles after HomeScreen has already mounted.
- **`didRetryRef: useRef<boolean>`** guard so the retry fires **at most once per hook instance**, bounding traffic against a persistently failing backend. A subsequent retry requires a hook remount (nav away and back), which is the explicit user signal that warrants another attempt.
- Early-return chain: `didRetryRef → hasLoaded → isLoading`.

### Tests

- **Regression test** (`useSuggestions.test.ts`): *"retries when HomeScreen mounts DURING an inflight prefetch that later fails"* — reproduces the exact production scenario. With the old empty-deps implementation, this test times out; with the new deps + ref guard, it passes.
- **Bounds test**: *"does not retry more than once per mount when the retry itself fails"* — locks in the retry-storm guard.
- **Test hygiene**: switched `beforeEach` from `jest.clearAllMocks()` to `mockGet.mockReset()` so queued `mockResolvedValueOnce` implementations from a timed-out test cannot leak into the next test's mock queue (discovered while iterating on the regression test).

### Verification

- [x] 312/312 unit tests pass (was 310 — added 2)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/features/home/hooks/useSuggestions.ts` clean
- [x] code-reviewer approved (confirmed StrictMode safety, ref semantics, dep array reactivity)
- [x] security-reviewer approved (no retry amplification, no cross-user leakage)
- [ ] Maestro E2E (flows already updated in #152 with `scrollUntilVisible`, should still work)
- [ ] **Manual cold-start smoke test on a production build** — this is the actual reproduction path and should be verified before final merge, since the failure mode is specific to real-device Firebase token warmup timing

## Test plan

- [ ] Install a fresh release build (clear app data / uninstall + reinstall so Firebase token cache is cold)
- [ ] Cold-start the app and immediately observe the Home screen
- [ ] Confirm suggestions are visible on the very first launch (no need to kill and relaunch)
- [ ] Repeat on both iOS and Android
- [ ] Optional: test the recovery path — force-close after a successful first launch, cold-start again, confirm suggestions still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)