### PR TITLE
ci: add lockfile cooldown guard to develop CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,25 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/test/test-claude-hooks.sh
 
+  lockfile-cooldown:
+    name: Lockfile cooldown guard
+    runs-on: ubuntu-latest
+    # Mirrors the Dockerfile guard at apps/api/Dockerfile:30 so a PR that
+    # regenerates apps/api/uv.lock without going through `make api-lock`
+    # (which injects --exclude-newer via scripts/uv-install.sh) is caught
+    # on develop instead of failing the Cloud Run deploy on merge to main.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify apps/api/uv.lock has exclude-newer cooldown
+        run: |
+          if ! grep -q '^exclude-newer = ' apps/api/uv.lock; then
+            echo "ERROR: apps/api/uv.lock is missing [options] exclude-newer." >&2
+            echo "       Regenerate the lockfile with 'make api-lock' so the" >&2
+            echo "       supply-chain release-age cooldown is recorded." >&2
+            exit 1
+          fi
+          echo "OK: $(grep '^exclude-newer = ' apps/api/uv.lock)"
+
   lint-api:
     name: Lint API
     needs: changes


### PR DESCRIPTION
## Summary

Add a develop-CI job that mirrors the Dockerfile supply-chain guard at \`apps/api/Dockerfile:30\`, so a PR that regenerates \`apps/api/uv.lock\` without going through \`make api-lock\` (= \`scripts/uv-install.sh lock\`) is caught on the PR instead of failing the Cloud Run deploy on merge to \`main\`.

## Background

- PR #158 regenerated \`apps/api/uv.lock\` with bare \`uv\` instead of \`make api-lock\`, stripping the \`exclude-newer = "..."\` cooldown metadata.
- Develop CI did not run the Dockerfile guard, so the regression went unnoticed.
- The deploy workflow on the develop → main release (#160) then failed at \`docker build\` builder step 6/7:
  > \`ERROR: uv.lock is missing [options] exclude-newer. Regenerate with 'make api-lock'.\`
- PR #161 restored the metadata; this PR prevents the same regression from recurring.

## Change

New job \`lockfile-cooldown\` in \`.github/workflows/ci.yml\`:

\`\`\`yaml
- name: Verify apps/api/uv.lock has exclude-newer cooldown
  run: |
    if ! grep -q '^exclude-newer = ' apps/api/uv.lock; then
      echo "ERROR: apps/api/uv.lock is missing [options] exclude-newer." >&2
      ...
      exit 1
    fi
\`\`\`

The job runs unconditionally (no \`paths-filter\` gate) so it cannot be silently skipped — the check is cheap (single grep).

## Verification

- [x] Positive case: \`grep -q '^exclude-newer = ' apps/api/uv.lock\` → PASS on develop HEAD
- [x] Negative case: grep against a missing file exits non-zero → guard fires
- [ ] CI run on this PR shows the new job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)