### PR TITLE
fix(api): type :embedding bindparam in backfill script for pgvector

### DIFF
--- a/apps/api/scripts/backfill_memory_embeddings.py
+++ b/apps/api/scripts/backfill_memory_embeddings.py
@@ -27,15 +27,24 @@ import asyncio
 import logging
 import sys
 import uuid
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector  # type: ignore[import-untyped]
+from sqlalchemy import bindparam
 
 from coyo.db import get_session_factory
 from coyo.services.embedding import get_embedding_service
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+
+# Module-level constant so the dim stays in sync with the column type
+# defined in alembic/versions/0010_add_memory_embeddings.py. Changing
+# the embedding model requires a new migration + backfill, so hardcoding
+# is safer than reading from settings at import time (a settings drift
+# would silently produce vectors the column rejects at runtime).
+_EMBEDDING_DIM: Final[int] = 1536
 
 logging.basicConfig(
     level=logging.INFO,
@@ -106,12 +115,19 @@ async def _update_interest_embeddings(
     rows: list[dict[str, object]],
     embeddings: list[list[float]],
 ) -> None:
-    """Write embeddings back, matching on the composite (user_id, keyword)."""
+    """Write embeddings back, matching on the composite (user_id, keyword).
+
+    The ``:embedding`` bind parameter is typed with ``Vector(1536)`` so
+    SQLAlchemy / asyncpg encode the Python ``list[float]`` via pgvector's
+    registered codec. Without this, asyncpg sees an unknown parameter
+    type and tries to encode the list as text, which raises
+    ``DataError: expected str, got list``.
+    """
     await session.execute(sa.text("SET LOCAL statement_timeout = '60s'"))
     stmt = sa.text(
         "UPDATE user_interests SET embedding = :embedding "
         "WHERE user_id = :user_id AND keyword = :keyword"
-    )
+    ).bindparams(bindparam("embedding", type_=Vector(_EMBEDDING_DIM)))
     for row, vec in zip(rows, embeddings, strict=True):
         await session.execute(
             stmt,
@@ -128,9 +144,15 @@ async def _update_summary_embeddings(
     rows: list[dict[str, object]],
     embeddings: list[list[float]],
 ) -> None:
-    """Write embeddings back, matching on the conversation summary id."""
+    """Write embeddings back, matching on the conversation summary id.
+
+    See ``_update_interest_embeddings`` for why the ``:embedding`` bind
+    parameter needs an explicit ``Vector(1536)`` type annotation.
+    """
     await session.execute(sa.text("SET LOCAL statement_timeout = '60s'"))
-    stmt = sa.text("UPDATE conversation_summaries SET embedding = :embedding WHERE id = :id")
+    stmt = sa.text(
+        "UPDATE conversation_summaries SET embedding = :embedding WHERE id = :id"
+    ).bindparams(bindparam("embedding", type_=Vector(_EMBEDDING_DIM)))
     for row, vec in zip(rows, embeddings, strict=True):
         row_id = row["id"]
         if isinstance(row_id, str):

--- a/apps/api/tests/unit/test_backfill_memory_embeddings.py
+++ b/apps/api/tests/unit/test_backfill_memory_embeddings.py
@@ -1,0 +1,192 @@
+"""Unit tests for the backfill script.
+
+Regression coverage for the production failure where the ``:embedding``
+bind parameter in the raw ``sa.text(...)`` UPDATE statements was not
+typed, causing asyncpg to attempt encoding the Python ``list[float]``
+as text and raising ``DataError: expected str, got list``.
+
+The bug was discovered while running:
+
+    DATABASE_URL='postgresql+asyncpg://...' \\
+      .venv/bin/python scripts/backfill_memory_embeddings.py --table all
+
+These tests don't require a live pgvector database — they introspect
+the SQLAlchemy ``TextClause`` produced by the helpers and verify that
+the ``embedding`` bind parameter carries an explicit ``Vector`` type
+annotation. Without that annotation, SQLAlchemy / asyncpg fall back to
+the generic text codec and the production failure reproduces.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from pgvector.sqlalchemy import Vector  # type: ignore[import-untyped]
+from sqlalchemy.sql.elements import TextClause
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_backfill_module() -> ModuleType:
+    """Load the backfill script as an importable module by file path.
+
+    The script lives outside the ``coyo`` package and is normally invoked
+    as a top-level executable, so it isn't on ``sys.path``. Loading it via
+    ``importlib`` keeps the test self-contained without requiring a
+    ``conftest.py`` ``sys.path`` hack.
+    """
+    script_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "backfill_memory_embeddings.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_backfill_memory_embeddings", script_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+backfill = _load_backfill_module()
+
+
+def _captured_text_stmt(execute_mock: AsyncMock) -> TextClause:
+    """Pull the second ``execute`` call's first positional arg.
+
+    The first call is always ``SET LOCAL statement_timeout``; the second
+    is the typed UPDATE statement we want to inspect.
+    """
+    assert execute_mock.await_count >= 2, (
+        f"expected at least 2 execute calls, got {execute_mock.await_count}"
+    )
+    update_call = execute_mock.await_args_list[1]
+    stmt = update_call.args[0]
+    assert isinstance(stmt, TextClause), f"expected TextClause, got {type(stmt)!r}"
+    return stmt
+
+
+def _embedding_bind_type(stmt: TextClause) -> object:
+    """Return the SQL type attached to the ``embedding`` bind param."""
+    bind = stmt._bindparams.get("embedding")  # noqa: SLF001 — unit-test introspection
+    assert bind is not None, "stmt has no :embedding bind param"
+    return bind.type
+
+
+@pytest.mark.unit
+async def test_update_interest_embeddings_uses_typed_bindparam():
+    """Regression: UPDATE must carry a ``Vector(1536)``-typed bind param.
+
+    Without ``bindparam("embedding", type_=Vector(1536))``, asyncpg
+    encodes the list as text and raises ``DataError`` against pgvector.
+    """
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    rows = [
+        {"user_id": uuid.uuid4(), "keyword": "tennis"},
+        {"user_id": uuid.uuid4(), "keyword": "ai"},
+    ]
+    embeddings = [[0.1] * 1536, [0.2] * 1536]
+
+    await backfill._update_interest_embeddings(session, rows, embeddings)  # noqa: SLF001
+
+    stmt = _captured_text_stmt(session.execute)
+    bind_type = _embedding_bind_type(stmt)
+    assert isinstance(bind_type, Vector), (
+        f"expected Vector type for :embedding, got {type(bind_type).__name__}"
+    )
+    assert bind_type.dim == 1536
+
+
+@pytest.mark.unit
+async def test_update_summary_embeddings_uses_typed_bindparam():
+    """Regression: same fix on the conversation_summaries UPDATE path."""
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    rows = [
+        {"id": uuid.uuid4()},
+        {"id": uuid.uuid4()},
+    ]
+    embeddings = [[0.3] * 1536, [0.4] * 1536]
+
+    await backfill._update_summary_embeddings(session, rows, embeddings)  # noqa: SLF001
+
+    stmt = _captured_text_stmt(session.execute)
+    bind_type = _embedding_bind_type(stmt)
+    assert isinstance(bind_type, Vector), (
+        f"expected Vector type for :embedding, got {type(bind_type).__name__}"
+    )
+    assert bind_type.dim == 1536
+
+
+@pytest.mark.unit
+async def test_update_interest_embeddings_executes_one_update_per_row():
+    """Verify each row results in exactly one UPDATE call."""
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    rows = [
+        {"user_id": uuid.uuid4(), "keyword": "tennis"},
+        {"user_id": uuid.uuid4(), "keyword": "ai"},
+        {"user_id": uuid.uuid4(), "keyword": "cooking"},
+    ]
+    embeddings = [[float(i)] * 1536 for i in range(3)]
+
+    await backfill._update_interest_embeddings(session, rows, embeddings)  # noqa: SLF001
+
+    # 1 SET LOCAL + 3 UPDATEs = 4 total
+    assert session.execute.await_count == 4
+    # Each UPDATE call should bind the matching keyword
+    for call_idx, expected_keyword in enumerate(["tennis", "ai", "cooking"], start=1):
+        params = session.execute.await_args_list[call_idx].args[1]
+        assert params["keyword"] == expected_keyword
+
+
+@pytest.mark.unit
+async def test_update_summary_embeddings_normalises_string_uuid():
+    """If a row's ``id`` arrives as a string it should be coerced to UUID."""
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    string_id = "c088e999-87de-4573-ac41-f56e46da8841"
+    rows = [{"id": string_id}]
+    embeddings = [[0.0] * 1536]
+
+    await backfill._update_summary_embeddings(session, rows, embeddings)  # noqa: SLF001
+
+    update_call = session.execute.await_args_list[1]
+    bound_id = update_call.args[1]["id"]
+    assert isinstance(bound_id, uuid.UUID)
+    assert str(bound_id) == string_id
+
+
+@pytest.mark.unit
+async def test_compose_helpers_match_production_format():
+    """Embedded text format must match what the live write path uses.
+
+    If these strings drift the backfill will produce embeddings that
+    rank differently from rows written by the production write path,
+    silently degrading retrieval quality.
+    """
+    assert backfill._compose_interest_text("tennis", None) == "tennis"  # noqa: SLF001
+    assert (
+        backfill._compose_interest_text("tennis", "plays weekends")  # noqa: SLF001
+        == "tennis: plays weekends"
+    )
+    assert (
+        backfill._compose_summary_text("kw", "Title", "Body")  # noqa: SLF001
+        == "kw\nBody"
+    )
+    assert (
+        backfill._compose_summary_text(None, "Title", "Body")  # noqa: SLF001
+        == "Title\nBody"
+    )


### PR DESCRIPTION
## Summary

The one-shot backfill script shipped in #158 fails in production with `asyncpg.exceptions.DataError: invalid input for query argument $1: [...] (expected str, got list)`. The raw `sa.text(...)` UPDATE statements bound `:embedding` without a SQLAlchemy type, so asyncpg defaulted to encoding the Python `list[float]` as text — which pgvector's `vector` column rejects.

This PR wraps both UPDATEs with `.bindparams(bindparam("embedding", type_=Vector(1536)))`, routing the parameter through pgvector-sqlalchemy's bind processor, and adds regression tests that would have caught the bug pre-merge.

## Why this wasn't caught in #158

- Local pytest runs against SQLite, where the column degrades to `LargeBinary`. The bind-time encoding never exercises pgvector.
- The migration's dialect-aware type swap masks the issue under unit tests.
- The database-reviewer **explicitly flagged this concern** during the original review:
  > "Confirm the `:embedding` parameter binding works with pgvector's psycopg/asyncpg drivers — I matched what `pgvector.sqlalchemy` does internally but couldn't run it against a live DB."
  
  That concern was acknowledged but not converted into a regression test. This PR adds the missing test coverage so the same drift cannot happen again.

## Production reproduction

```
DATABASE_URL='postgresql+asyncpg://...' \
  .venv/bin/python scripts/backfill_memory_embeddings.py --table all

2026-04-09 16:16:43,155 [INFO] user_interests: 10 rows need embeddings
2026-04-09 16:16:45,568 [INFO] HTTP Request: POST https://api.openai.com/v1/embeddings "HTTP/1.1 200 OK"
Traceback (most recent call last):
  ...
  asyncpg.exceptions.DataError: invalid input for query argument $1:
  [-0.033538818359375, -0.022979736328125, ...] (expected str, got list)
  [SQL: UPDATE user_interests SET embedding = $1 WHERE user_id = $2 AND keyword = $3]
```

The script is idempotent — rows whose UPDATE failed (e.g. the `jannik sinner` interest in the production trace) will be re-picked up by `WHERE embedding IS NULL` on the next run after this fix lands.

## What changed

**`apps/api/scripts/backfill_memory_embeddings.py`**
- New imports: `from pgvector.sqlalchemy import Vector` and `from sqlalchemy import bindparam`.
- New module-level constant `_EMBEDDING_DIM: Final[int] = 1536`. **Intentionally hardcoded** to match the migration column type. Reading from `Settings.embedding_dim` would introduce a silent failure mode where a config drift produces vectors the column rejects at runtime instead of at code-review time.
- Both `_update_interest_embeddings` and `_update_summary_embeddings` now wrap their `sa.text(...)` UPDATE with `.bindparams(bindparam("embedding", type_=Vector(_EMBEDDING_DIM)))`.
- Inline docstrings explain the fix so future spelunkers understand the bind-typing requirement.

**`apps/api/tests/unit/test_backfill_memory_embeddings.py`** (new)
- 5 unit tests, all using `AsyncMock` sessions — no live DB required.
- Two regression tests inspect the compiled `TextClause._bindparams` and assert the `embedding` bind has a `Vector(1536)` type.
- Verified TDD-style: stash the fix → both regression tests fail → restore the fix → all 5 pass.
- Loads the script via `importlib.util.spec_from_file_location` since it lives outside the `coyo` package. This avoids `sys.path` hacks and keeps the test self-contained.
- Also adds:
  - `test_update_interest_embeddings_executes_one_update_per_row` — guards against silent row/embedding misalignment
  - `test_update_summary_embeddings_normalises_string_uuid` — covers the existing `str → UUID` coercion path
  - `test_compose_helpers_match_production_format` — drift-detection: if the embedded text format ever diverges from what the production write path uses, the backfill would silently produce wrongly-ranked embeddings

## Reviews

- **code-reviewer**: APPROVE. Confirmed `bindparam("embedding", type_=Vector(_EMBEDDING_DIM))` is the canonical pgvector-sqlalchemy pattern. Validated the `_EMBEDDING_DIM` hardcode rationale, the `_bindparams` introspection approach, and the `importlib` script-loading idiom.
- **security-reviewer**: APPROVE. No new SQL injection surface (parameterized binds throughout, static `_NULL_COUNT_SQL` dispatch dict). No sensitive data logged. Operator-only invariant verified — the script is not imported by any FastAPI router or background worker. Test fixtures contain no real credentials.
- **python-reviewer**: NEEDS-CHANGE → fixed. Added `Final[int]` to `_EMBEDDING_DIM` and `-> ModuleType` to `_load_backfill_module`. ruff TC003 fix moves `ModuleType` into a `TYPE_CHECKING` block.

## Tests

- [x] `pytest -q` green: **699 passed** (694 baseline + 5 new)
- [x] `ruff check src/ scripts/` clean
- [x] `mypy` strict clean on touched files
- [x] Regression tests verified to fail without the fix (TDD red phase)
- [x] No E2E required — backend-only operator script, no user-visible behavior change

## Operator notes

After this lands and is deployed (or even just `git pull` on the operator's machine), the previously-failing backfill can be retried:

```bash
DATABASE_URL='postgresql+asyncpg://...' \
  .venv/bin/python scripts/backfill_memory_embeddings.py --dry-run --table all

DATABASE_URL='postgresql+asyncpg://...' \
  .venv/bin/python scripts/backfill_memory_embeddings.py --table all
```

Refs: #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)