### PR TITLE
refactor: rename user_profile_attributes table to user_attributes

### DIFF
--- a/apps/api/alembic/versions/20260413_000000_0011_rename_user_profile_attributes.py
+++ b/apps/api/alembic/versions/20260413_000000_0011_rename_user_profile_attributes.py
@@ -1,0 +1,50 @@
+"""Rename user_profile_attributes table to user_attributes.
+
+Renames:
+- Table: user_profile_attributes → user_attributes
+- PK index: user_profile_attributes_pkey → user_attributes_pkey
+- Check constraint: ck_user_profile_attributes_key → ck_user_attributes_key
+- FK constraint: user_profile_attributes_user_id_fkey → user_attributes_user_id_fkey
+
+All operations are metadata-only (no data movement).
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-04-13 00:00:00+00:00
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.rename_table("user_profile_attributes", "user_attributes")
+    op.execute("ALTER INDEX user_profile_attributes_pkey RENAME TO user_attributes_pkey")
+    op.execute(
+        "ALTER TABLE user_attributes RENAME CONSTRAINT "
+        "ck_user_profile_attributes_key TO ck_user_attributes_key"
+    )
+    op.execute(
+        "ALTER TABLE user_attributes RENAME CONSTRAINT "
+        "user_profile_attributes_user_id_fkey TO user_attributes_user_id_fkey"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE user_attributes RENAME CONSTRAINT "
+        "user_attributes_user_id_fkey TO user_profile_attributes_user_id_fkey"
+    )
+    op.execute(
+        "ALTER TABLE user_attributes RENAME CONSTRAINT "
+        "ck_user_attributes_key TO ck_user_profile_attributes_key"
+    )
+    op.execute("ALTER INDEX user_attributes_pkey RENAME TO user_profile_attributes_pkey")
+    op.rename_table("user_attributes", "user_profile_attributes")

--- a/apps/api/src/coyo/models/__init__.py
+++ b/apps/api/src/coyo/models/__init__.py
@@ -10,8 +10,8 @@ from coyo.models.correction import CorrectionItem, TurnCorrection
 from coyo.models.topic_suggestion import TopicSuggestion, UserTopicSuggestion
 from coyo.models.turn import Turn
 from coyo.models.user import User, UserSettings
+from coyo.models.user_attribute import UserAttribute
 from coyo.models.user_interest import UserInterest
-from coyo.models.user_profile_attribute import UserProfileAttribute
 from coyo.models.user_profile_summary import UserProfileSummary
 
 __all__ = [
@@ -23,8 +23,8 @@ __all__ = [
     "Turn",
     "TurnCorrection",
     "User",
+    "UserAttribute",
     "UserInterest",
-    "UserProfileAttribute",
     "UserProfileSummary",
     "UserSettings",
     "UserTopicSuggestion",

--- a/apps/api/src/coyo/models/user_attribute.py
+++ b/apps/api/src/coyo/models/user_attribute.py
@@ -1,4 +1,4 @@
-"""UserProfileAttribute ORM model for structured user profile facts."""
+"""UserAttribute ORM model for structured user profile facts."""
 
 from __future__ import annotations
 
@@ -13,18 +13,18 @@ from sqlalchemy.orm import Mapped, mapped_column
 from coyo.models.base import Base
 
 
-class UserProfileAttribute(Base):
+class UserAttribute(Base):
     """Stores a structured profile fact about a user.
 
     Each attribute is a key-value pair with a confidence score.
     Allowed keys: english_goal, job_industry, hometown_or_location, family_status.
     """
 
-    __tablename__ = "user_profile_attributes"
+    __tablename__ = "user_attributes"
     __table_args__ = (
         sa.CheckConstraint(
             "key IN ('english_goal', 'job_industry', 'hometown_or_location', 'family_status')",
-            name="ck_user_profile_attributes_key",
+            name="ck_user_attributes_key",
         ),
     )
 

--- a/apps/api/src/coyo/repositories/profile_attribute.py
+++ b/apps/api/src/coyo/repositories/profile_attribute.py
@@ -1,4 +1,4 @@
-"""Repository for UserProfileAttribute data access."""
+"""Repository for UserAttribute data access."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
-from coyo.models.user_profile_attribute import UserProfileAttribute
+from coyo.models.user_attribute import UserAttribute
 
 if TYPE_CHECKING:
     import uuid
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class ProfileAttributeRepository:
-    """Encapsulates database operations for the UserProfileAttribute model."""
+    """Encapsulates database operations for the UserAttribute model."""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -25,10 +25,10 @@ class ProfileAttributeRepository:
     async def get_all_for_user(
         self,
         user_id: uuid.UUID,
-    ) -> list[UserProfileAttribute]:
+    ) -> list[UserAttribute]:
         """Get all profile attributes for a user."""
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == user_id,
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == user_id,
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
@@ -37,11 +37,11 @@ class ProfileAttributeRepository:
         self,
         user_id: uuid.UUID,
         key: str,
-    ) -> UserProfileAttribute | None:
+    ) -> UserAttribute | None:
         """Get a specific profile attribute by key."""
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == user_id,
-            UserProfileAttribute.key == key,
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == user_id,
+            UserAttribute.key == key,
         )
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
@@ -53,20 +53,20 @@ class ProfileAttributeRepository:
         key: str,
         value: str,
         confidence: float,
-    ) -> UserProfileAttribute:
+    ) -> UserAttribute:
         """Insert or update a profile attribute.
 
         On update, also updates the updated_at timestamp.
         """
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == user_id,
-            UserProfileAttribute.key == key,
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == user_id,
+            UserAttribute.key == key,
         )
         result = await self._session.execute(stmt)
         attr = result.scalar_one_or_none()
 
         if attr is None:
-            attr = UserProfileAttribute(
+            attr = UserAttribute(
                 user_id=user_id,
                 key=key,
                 value=value,
@@ -79,9 +79,9 @@ class ProfileAttributeRepository:
                 # Concurrent insert race — rollback and fall through to update
                 await self._session.rollback()
                 result = await self._session.execute(
-                    select(UserProfileAttribute).where(
-                        UserProfileAttribute.user_id == user_id,
-                        UserProfileAttribute.key == key,
+                    select(UserAttribute).where(
+                        UserAttribute.user_id == user_id,
+                        UserAttribute.key == key,
                     )
                 )
                 attr = result.scalar_one()
@@ -100,12 +100,12 @@ class ProfileAttributeRepository:
     async def delete(self, user_id: uuid.UUID, key: str) -> bool:
         """Delete a profile attribute. Returns True if deleted, False if not found."""
         stmt = (
-            delete(UserProfileAttribute)
+            delete(UserAttribute)
             .where(
-                UserProfileAttribute.user_id == user_id,
-                UserProfileAttribute.key == key,
+                UserAttribute.user_id == user_id,
+                UserAttribute.key == key,
             )
-            .returning(UserProfileAttribute.user_id)
+            .returning(UserAttribute.user_id)
         )
         result = await self._session.execute(stmt)
         await self._session.flush()

--- a/apps/api/src/coyo/services/memory_context.py
+++ b/apps/api/src/coyo/services/memory_context.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from coyo.models.conversation_summary import ConversationSummary
-    from coyo.models.user_profile_attribute import UserProfileAttribute
+    from coyo.models.user_attribute import UserAttribute
     from coyo.models.user_profile_summary import UserProfileSummary
     from coyo.services.theme_context import ThemeContext
 
@@ -428,7 +428,7 @@ def _dedupe_summaries_top_up(
 def _format_memory_block(
     *,
     profile_summary: UserProfileSummary | None,
-    profile_attrs: list[UserProfileAttribute],
+    profile_attrs: list[UserAttribute],
     top_interests: list[InterestWithWeight],
     recent_summaries: list[ConversationSummary],
 ) -> str:

--- a/apps/api/src/coyo/services/memory_extraction.py
+++ b/apps/api/src/coyo/services/memory_extraction.py
@@ -294,7 +294,7 @@ _PROFILE_SUMMARY_PROMPT = """\
 You are synthesizing a user profile for a personalized English conversation app.
 
 [User's background attributes]
-{user_profile_attributes}
+{user_attributes}
 
 [User's top interests with summaries]
 {interests_with_summaries}
@@ -799,7 +799,7 @@ class MemoryExtractionService:
             convs_text = "(no recent conversations)"
 
         prompt = _PROFILE_SUMMARY_PROMPT.format(
-            user_profile_attributes=attrs_text,
+            user_attributes=attrs_text,
             interests_with_summaries=interests_text,
             recent_conversations=convs_text,
         )

--- a/apps/api/tests/unit/test_memory_context.py
+++ b/apps/api/tests/unit/test_memory_context.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.models.conversation_summary import ConversationSummary
 from coyo.models.user import User
-from coyo.models.user_profile_attribute import UserProfileAttribute
+from coyo.models.user_attribute import UserAttribute
 from coyo.models.user_profile_summary import UserProfileSummary
 from coyo.repositories.conversation_summary import (
     ConversationSummaryEmbeddingRow,
@@ -68,7 +68,7 @@ class TestBuildContext:
         db_session.add(profile_summary)
 
         # Create profile attribute
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="Software Engineer",
@@ -314,13 +314,13 @@ class TestFormatMemoryBlock:
         """Attributes should be formatted with key, value, and confidence."""
         attrs = [
             MagicMock(
-                spec=UserProfileAttribute,
+                spec=UserAttribute,
                 key="job_industry",
                 value="Software Engineer",
                 confidence=0.9,
             ),
             MagicMock(
-                spec=UserProfileAttribute,
+                spec=UserAttribute,
                 key="hometown_or_location",
                 value="Tokyo",
                 confidence=0.8,

--- a/apps/api/tests/unit/test_memory_extraction.py
+++ b/apps/api/tests/unit/test_memory_extraction.py
@@ -13,7 +13,7 @@ from coyo.models.conversation import Conversation
 from coyo.models.conversation_summary import ConversationSummary
 from coyo.models.turn import Turn
 from coyo.models.user import User
-from coyo.models.user_profile_attribute import UserProfileAttribute
+from coyo.models.user_attribute import UserAttribute
 from coyo.services.memory_extraction import (
     KeywordItem,
     MemoryExtractionResult,
@@ -354,9 +354,9 @@ class TestExtractMemories:
                 db_session, conversation.id, test_user.id
             )
 
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         result = await db_session.execute(stmt)
         attr = result.scalar_one_or_none()
@@ -370,7 +370,7 @@ class TestExtractMemories:
     ):
         """Existing attribute should be updated when new confidence is higher."""
         # Pre-create an attribute with lower confidence
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="IT Worker",
@@ -421,9 +421,9 @@ class TestExtractMemories:
                 db_session, conversation.id, test_user.id
             )
 
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         result = await db_session.execute(stmt)
         updated_attr = result.scalar_one()
@@ -435,7 +435,7 @@ class TestExtractMemories:
         self, db_session: AsyncSession, test_user: User
     ):
         """NOOP when value is semantically the same."""
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="Software Engineer",
@@ -486,9 +486,9 @@ class TestExtractMemories:
                 db_session, conversation.id, test_user.id
             )
 
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         result = await db_session.execute(stmt)
         unchanged_attr = result.scalar_one()
@@ -501,7 +501,7 @@ class TestExtractMemories:
         self, db_session: AsyncSession, test_user: User
     ):
         """NOOP when new confidence is lower than existing."""
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="Software Engineer",
@@ -552,9 +552,9 @@ class TestExtractMemories:
                 db_session, conversation.id, test_user.id
             )
 
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         result = await db_session.execute(stmt)
         unchanged_attr = result.scalar_one()
@@ -566,7 +566,7 @@ class TestExtractMemories:
         self, db_session: AsyncSession, test_user: User
     ):
         """DELETE when is_negation=True and attribute exists."""
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="family_status",
             value="Married",
@@ -618,9 +618,9 @@ class TestExtractMemories:
                 db_session, conversation.id, test_user.id
             )
 
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "family_status",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "family_status",
         )
         result = await db_session.execute(stmt)
         deleted_attr = result.scalar_one_or_none()

--- a/apps/api/tests/unit/test_profile_attribute_repository.py
+++ b/apps/api/tests/unit/test_profile_attribute_repository.py
@@ -1,13 +1,11 @@
 """Unit tests for the ProfileAttributeRepository."""
 
-import uuid
-
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.models.user import User
-from coyo.models.user_profile_attribute import UserProfileAttribute
+from coyo.models.user_attribute import UserAttribute
 from coyo.repositories.profile_attribute import ProfileAttributeRepository
 
 
@@ -30,13 +28,13 @@ class TestGetAllForUser:
         """Should return all attributes for the user."""
         repo = ProfileAttributeRepository(db_session)
 
-        attr1 = UserProfileAttribute(
+        attr1 = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="IT",
             confidence=0.9,
         )
-        attr2 = UserProfileAttribute(
+        attr2 = UserAttribute(
             user_id=test_user.id,
             key="hometown_or_location",
             value="Tokyo",
@@ -72,9 +70,9 @@ class TestUpsert:
         assert result.confidence == 0.9
 
         # Verify it is in the database
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         db_result = await db_session.execute(stmt)
         attr = db_result.scalar_one()
@@ -88,7 +86,7 @@ class TestUpsert:
         repo = ProfileAttributeRepository(db_session)
 
         # Create initial attribute
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="IT",
@@ -109,9 +107,9 @@ class TestUpsert:
         assert result.confidence == 0.9
 
         # Verify only one record exists
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "job_industry",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "job_industry",
         )
         db_result = await db_session.execute(stmt)
         attrs = db_result.scalars().all()
@@ -129,7 +127,7 @@ class TestDelete:
         """Should return True when attribute is successfully deleted."""
         repo = ProfileAttributeRepository(db_session)
 
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="family_status",
             value="Married",
@@ -142,9 +140,9 @@ class TestDelete:
         assert result is True
 
         # Verify it is deleted
-        stmt = select(UserProfileAttribute).where(
-            UserProfileAttribute.user_id == test_user.id,
-            UserProfileAttribute.key == "family_status",
+        stmt = select(UserAttribute).where(
+            UserAttribute.user_id == test_user.id,
+            UserAttribute.key == "family_status",
         )
         db_result = await db_session.execute(stmt)
         assert db_result.scalar_one_or_none() is None
@@ -170,7 +168,7 @@ class TestGetByKey:
         """Should return the attribute when found."""
         repo = ProfileAttributeRepository(db_session)
 
-        attr = UserProfileAttribute(
+        attr = UserAttribute(
             user_id=test_user.id,
             key="job_industry",
             value="IT",

--- a/docs/DEPLOY-MEMORY.md
+++ b/docs/DEPLOY-MEMORY.md
@@ -21,7 +21,7 @@ The memory feature adds user personalization to conversations by:
         │                                      │
         │                              ┌───────┼───────┐
         │                              ▼       ▼       ▼
-        │                     [user_interests] [user_profile_attributes] [conversation_summaries]
+        │                     [user_interests] [user_attributes] [conversation_summaries]
         │                              │
         │                     (every 5th conversation)
         │                              │
@@ -38,7 +38,7 @@ The memory feature adds user personalization to conversations by:
 [Load memory context] ──▶ [Inject into system prompt]
         │
         ├── user_profile_summary (narrative)
-        ├── user_profile_attributes (4 background items)
+        ├── user_attributes (4 background items)
         ├── user_interests top 20 (with summaries)
         └── conversation_summaries last 5
 ```
@@ -86,7 +86,7 @@ Merge the PR to `main`. The existing `deploy-api.yml` GitHub Actions workflow ha
 
 1. **Build** Docker image → push to Artifact Registry
 2. **Migrate** — `alembic upgrade head` creates:
-   - `user_profile_attributes` table
+   - `user_attributes` table
    - `user_profile_summaries` table
    - `conversation_summaries` table
    - New columns on `user_interests` (summary, summary_updated_at, needs_summary_update)
@@ -178,7 +178,7 @@ gcloud tasks queues describe memory-extraction \
    WHERE summary IS NOT NULL LIMIT 10;
 
    -- Profile attributes extracted (if user shared background info)
-   SELECT * FROM user_profile_attributes ORDER BY created_at DESC LIMIT 10;
+   SELECT * FROM user_attributes ORDER BY created_at DESC LIMIT 10;
    ```
 5. Start a new conversation and verify the AI references prior context naturally
 

--- a/docs/DEPLOY-TOPIC-SUGGESTION.md
+++ b/docs/DEPLOY-TOPIC-SUGGESTION.md
@@ -24,7 +24,7 @@ The topic suggestion feature consists of two pipelines:
         │                                      │
         │                                      ▼
         │                            [Store in user_interests +
-        │                             user_profile_attributes +
+        │                             user_attributes +
         │                             conversation_summaries]
         │
 ========│=========== (daily at 06:00 JST) ==========================


### PR DESCRIPTION
## Summary

- Rename the `user_profile_attributes` database table to `user_attributes` for consistency and clarity
- Add Alembic migration (0011) that renames table, PK index, check constraint, and FK constraint (all metadata-only, no data movement)
- Rename ORM class `UserProfileAttribute` → `UserAttribute` and model file `user_profile_attribute.py` → `user_attribute.py`
- Update all references across repositories, services, tests, and documentation

Closes #139

## Test plan

- [x] All 48 affected unit tests pass (repository, memory extraction, memory context)
- [x] Full test suite shows no new failures (same 16 failures + 69 errors as develop)
- [x] Pre-commit hooks pass (ruff, mypy)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)