### PR TITLE
feat(api): upsert topic keyword as interest and fix common topics generation

### DIFF
--- a/apps/api/alembic/versions/20260413_000001_0012_add_conversation_topic_column.py
+++ b/apps/api/alembic/versions/20260413_000001_0012_add_conversation_topic_column.py
@@ -1,0 +1,33 @@
+"""Add topic column to conversations table.
+
+Stores the topic key selected by the user (sports, business, etc.)
+so memory extraction can resolve the topic keyword for interest upsert.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-04-13 00:00:01+00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: str = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "topic",
+            sa.String(20),
+            nullable=True,
+            comment="Topic key selected by user (sports, business, etc. or 'suggested')",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "topic")

--- a/apps/api/src/coyo/models/conversation.py
+++ b/apps/api/src/coyo/models/conversation.py
@@ -71,6 +71,12 @@ class Conversation(BaseModel):
         default=None,
         index=True,
     )
+    topic: Mapped[str | None] = mapped_column(
+        String(20),
+        nullable=True,
+        default=None,
+        comment="Topic key selected by user (sports, business, etc. or 'suggested')",
+    )
     interests_extracted: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,

--- a/apps/api/src/coyo/repositories/conversation.py
+++ b/apps/api/src/coyo/repositories/conversation.py
@@ -21,12 +21,14 @@ class ConversationRepository:
         user_id: uuid.UUID,
         time_limit_seconds: int,
         topic_suggestion_id: uuid.UUID | None = None,
+        topic: str | None = None,
     ) -> Conversation:
         """Create a new conversation and flush to obtain its ID."""
         conversation = Conversation(
             user_id=user_id,
             time_limit_seconds=time_limit_seconds,
             topic_suggestion_id=topic_suggestion_id,
+            topic=topic,
         )
         self._session.add(conversation)
         await self._session.flush()

--- a/apps/api/src/coyo/repositories/interest.py
+++ b/apps/api/src/coyo/repositories/interest.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 from coyo.models.user_interest import UserInterest
@@ -339,3 +339,28 @@ class InterestRepository:
                 )
             )
         return rows
+
+    async def get_global_top_keywords(
+        self,
+        *,
+        keyword_type: str = "category",
+        is_news_relevant: bool = True,
+        limit: int = 3,
+    ) -> list[str]:
+        """Get the most popular keywords across all users by user count.
+
+        Used by common topic generation to select keywords that are relevant
+        to the broadest audience.
+        """
+        stmt = (
+            select(UserInterest.keyword)
+            .where(
+                UserInterest.keyword_type == keyword_type,
+                UserInterest.is_news_relevant == is_news_relevant,
+            )
+            .group_by(UserInterest.keyword)
+            .order_by(func.count(func.distinct(UserInterest.user_id)).desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())

--- a/apps/api/src/coyo/services/conversation.py
+++ b/apps/api/src/coyo/services/conversation.py
@@ -82,6 +82,7 @@ class ConversationService:
             user_id=user_id,
             time_limit_seconds=time_limit_seconds,
             topic_suggestion_id=topic_suggestion_id,
+            topic=topic,
         )
         await self._session.commit()
         return conversation

--- a/apps/api/src/coyo/services/memory_extraction.py
+++ b/apps/api/src/coyo/services/memory_extraction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 import structlog
@@ -15,6 +16,7 @@ from coyo.models.conversation import Conversation
 from coyo.models.topic_suggestion import TopicSuggestion
 from coyo.models.turn import Turn
 from coyo.models.user import User
+from coyo.models.user_interest import UserInterest
 from coyo.repositories.conversation_summary import ConversationSummaryRepository
 from coyo.repositories.interest import InterestRepository
 from coyo.repositories.profile_attribute import ProfileAttributeRepository
@@ -35,6 +37,24 @@ _MAX_KEYWORD_LENGTH = 100
 _MAX_SUMMARY_LENGTH = 200
 _CONFIDENCE_THRESHOLD = 0.5
 _BATCH_INTERVAL = 5
+
+
+@dataclass(frozen=True)
+class _IABMapping:
+    """Maps a fixed topic key to its IAB Content Taxonomy v3.1 Tier 1 category."""
+
+    keyword: str  # IAB category name (lowercased)
+    iab_id: str  # IAB category ID
+
+
+# Fixed topic key → IAB Content Taxonomy v3.1 Tier 1
+_FIXED_TOPIC_IAB: dict[str, _IABMapping] = {
+    "sports": _IABMapping(keyword="sports", iab_id="483"),
+    "business": _IABMapping(keyword="business and finance", iab_id="52"),
+    "technology": _IABMapping(keyword="technology & computing", iab_id="596"),
+    "politics": _IABMapping(keyword="politics", iab_id="386"),
+    "entertainment": _IABMapping(keyword="entertainment", iab_id="JLBCU7"),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -471,7 +491,7 @@ class MemoryExtractionService:
 
         # 7. Upsert interests (categories + entities) via post-processing pipeline
         seen_keywords = await MemoryExtractionService._upsert_interests(
-            session, user_id, extraction, current_conv_idx
+            session, user_id, extraction, current_conv_idx, conversation
         )
 
         # 8. Batch regeneration every N conversations
@@ -618,6 +638,7 @@ class MemoryExtractionService:
         user_id: uuid.UUID,
         extraction: MemoryExtractionResult,
         current_conv_idx: int,
+        conversation: Conversation,
     ) -> set[str]:
         """Upsert interest keywords via the post-processing pipeline."""
         from coyo.services.embedding import get_embedding_service
@@ -679,7 +700,88 @@ class MemoryExtractionService:
                     embedding=kw.embedding if kw.merge_target is None else None,
                 )
 
+        # --- Topic keyword injection (post-pipeline) ---
+        await MemoryExtractionService._upsert_topic_keyword(
+            session, repo, user_id, current_conv_idx, conversation, seen_keywords
+        )
+
         return seen_keywords
+
+    @staticmethod
+    async def _upsert_topic_keyword(
+        session: AsyncSession,
+        repo: InterestRepository,
+        user_id: uuid.UUID,
+        current_conv_idx: int,
+        conversation: Conversation,
+        seen_keywords: set[str],
+    ) -> None:
+        """Upsert the conversation's topic keyword as a user interest.
+
+        Runs after the postprocessor pipeline. Skips if the keyword was
+        already extracted by the LLM (present in seen_keywords).
+        """
+        topic_kw, topic_iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            session, conversation
+        )
+        if not topic_kw or topic_kw in seen_keywords:
+            return
+
+        # Determine is_news_relevant from existing interest, default True
+        is_news_relevant = True
+        existing_stmt = select(UserInterest).where(
+            UserInterest.user_id == user_id,
+            UserInterest.keyword == topic_kw,
+        )
+        result = await session.execute(existing_stmt)
+        existing_interest = result.scalar_one_or_none()
+        if existing_interest is not None:
+            is_news_relevant = existing_interest.is_news_relevant
+
+        # Compute embedding only for brand-new keywords
+        embedding: list[float] | None = None
+        if existing_interest is None:
+            from coyo.services.embedding import get_embedding_service
+
+            embedding_service = get_embedding_service()
+            vectors = await embedding_service.embed([topic_kw])
+            embedding = vectors[0] if vectors else None
+
+        seen_keywords.add(topic_kw)
+        await repo.upsert_interest(
+            user_id=user_id,
+            keyword=topic_kw,
+            keyword_type="category",
+            is_news_relevant=is_news_relevant,
+            current_conv_idx=current_conv_idx,
+            summary=None,
+            iab_category_id=topic_iab_id,
+            embedding=embedding,
+        )
+
+    @staticmethod
+    async def _resolve_topic_keyword(
+        session: AsyncSession,
+        conversation: Conversation,
+    ) -> tuple[str | None, str | None]:
+        """Resolve topic keyword and IAB category ID from a conversation.
+
+        Returns (keyword, iab_category_id) tuple:
+        - Suggested topic → (source_keyword, None)
+        - Fixed topic → (IAB category name, IAB ID) via _FIXED_TOPIC_IAB
+        - No topic → (None, None)
+        """
+        if conversation.topic_suggestion_id is not None:
+            suggestion = await session.get(
+                TopicSuggestion, conversation.topic_suggestion_id
+            )
+            if suggestion is not None:
+                return suggestion.source_keyword.lower().strip(), None
+        elif conversation.topic is not None and conversation.topic != "suggested":
+            mapping = _FIXED_TOPIC_IAB.get(conversation.topic.lower().strip())
+            if mapping is not None:
+                return mapping.keyword, mapping.iab_id
+        return None, None
 
     @staticmethod
     async def _regenerate_interest_summaries(

--- a/apps/api/src/coyo/services/topic_generation.py
+++ b/apps/api/src/coyo/services/topic_generation.py
@@ -130,7 +130,10 @@ class TopicGenerationService:
         self._llm = OpenAIClient(model=settings.llm_topic_model)
 
     async def generate_common_topics(self) -> int:
-        """Generate common trending topics for today.
+        """Generate common topics for today from global top keywords.
+
+        Uses the most popular user-interest keywords across all users.
+        Falls back to LLM trending search when no keywords exist (cold start).
 
         Returns the number of topics successfully generated.
         """
@@ -142,28 +145,79 @@ class TopicGenerationService:
             logger.info("topics_already_generated", date=str(today), count=len(existing))
             return len(existing)
 
-        # Use web search to find trending topics
         logger.info("topic_generation_start")
+
+        # Try interest-keyword-driven generation first
+        top_keywords = await self._interest_repo.get_global_top_keywords(
+            limit=_MAX_TOPICS,
+        )
+
+        if top_keywords:
+            return await self._generate_common_from_keywords(
+                top_keywords, today
+            )
+
+        # Cold start: no user keywords yet, fall back to LLM trending search
+        logger.info("common_topics_cold_start_fallback")
+        return await self._generate_common_from_trending(today)
+
+    async def _generate_common_from_keywords(
+        self, keywords: list[str], today: date
+    ) -> int:
+        """Generate common topics by searching news for each keyword."""
+        count = 0
+        for keyword in keywords:
+            topic = await self._fetch_personal_topic(keyword, today)
+            if topic is None:
+                logger.warning(
+                    "common_keyword_topic_fetch_failed",
+                    keyword=keyword[:50],
+                )
+                continue
+            try:
+                async with self._session.begin_nested():
+                    await self._repo.create_suggestion(
+                        title=topic.title,
+                        summary=topic.summary,
+                        source_keyword=keyword,
+                        article_content=topic.article_content,
+                        article_url=None,
+                        pool_type="common",
+                        generated_date=today,
+                    )
+                count += 1
+            except IntegrityError:
+                logger.warning(
+                    "topic_save_error", keyword=keyword[:50]
+                )
+
+        await self._session.commit()
+        logger.info("topic_generation_done", count=count, source="keywords")
+        return count
+
+    async def _generate_common_from_trending(self, today: date) -> int:
+        """Cold-start fallback: generate common topics via LLM trending search."""
         result = await self._fetch_topics()
 
         count = 0
         for item in result.topics[:_MAX_TOPICS]:
             try:
-                await self._repo.create_suggestion(
-                    title=item.title,
-                    summary=item.summary,
-                    source_keyword=item.source_keyword,
-                    article_content=item.article_content,
-                    article_url=None,
-                    pool_type="common",
-                    generated_date=today,
-                )
+                async with self._session.begin_nested():
+                    await self._repo.create_suggestion(
+                        title=item.title,
+                        summary=item.summary,
+                        source_keyword=item.source_keyword,
+                        article_content=item.article_content,
+                        article_url=None,
+                        pool_type="common",
+                        generated_date=today,
+                    )
                 count += 1
             except IntegrityError:
-                logger.exception("topic_save_error", title=item.title)
+                logger.warning("topic_save_error", title=item.title)
 
         await self._session.commit()
-        logger.info("topic_generation_done", count=count)
+        logger.info("topic_generation_done", count=count, source="trending")
         return count
 
     async def assign_to_users(self) -> int:

--- a/apps/api/tests/unit/test_generate_common_topics.py
+++ b/apps/api/tests/unit/test_generate_common_topics.py
@@ -1,0 +1,198 @@
+"""Unit tests for TopicGenerationService.generate_common_topics (keyword-driven rewrite)."""
+
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.services.topic_generation import TopicGenerationService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_topic_json(count: int = 3) -> str:
+    """Build a valid JSON string for TopicSearchResult with `count` topics."""
+    topics = []
+    for i in range(count):
+        topics.append(
+            f'{{"title":"Topic {i}","summary":"Summary {i}",'
+            f'"source_keyword":"kw{i}","article_content":"Content {i}"}}'
+        )
+    return '{"topics":[' + ",".join(topics) + "]}"
+
+
+def _make_personal_topic_json(index: int = 0) -> str:
+    """Build a valid JSON string for PersonalTopicItem (single topic)."""
+    return (
+        f'{{"title":"Topic {index}","summary":"Summary {index}",'
+        f'"article_content":"Content {index}"}}'
+    )
+
+
+def _make_suggestion_mock(suggestion_id: uuid.UUID | None = None):
+    """Create a mock TopicSuggestion object."""
+    mock = MagicMock()
+    mock.id = suggestion_id or uuid.uuid4()
+    mock.title = "Test Topic"
+    mock.summary = "Test Summary"
+    mock.source_keyword = "test"
+    mock.article_content = "Test content"
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests for keyword-driven generate_common_topics
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCommonTopicsKeywordDriven:
+    """Tests for generate_common_topics with interest-keyword-driven generation."""
+
+    @pytest.fixture
+    def mock_repo(self):
+        """Create a mock TopicSuggestionRepository."""
+        repo = AsyncMock()
+        repo.get_common_suggestions = AsyncMock(return_value=[])
+        repo.create_suggestion = AsyncMock(return_value=_make_suggestion_mock())
+        return repo
+
+    @pytest.fixture
+    def mock_interest_repo(self):
+        """Create a mock InterestRepository."""
+        repo = AsyncMock()
+        repo.get_global_top_keywords = AsyncMock(
+            return_value=["sports", "technology", "music"]
+        )
+        return repo
+
+    @pytest.fixture
+    def mock_llm(self):
+        """Create a mock OpenAIClient that returns valid personal topic JSON."""
+        from coyo.services.llm.base import TextChunk
+
+        mock = MagicMock()
+
+        async def mock_chat_with_tools(messages, options=None):
+            yield TextChunk(text=_make_personal_topic_json())
+
+        mock.chat_with_tools = mock_chat_with_tools
+        return mock
+
+    @pytest.fixture
+    def service(
+        self,
+        db_session: AsyncSession,
+        mock_repo,
+        mock_interest_repo,
+        mock_llm,
+    ):
+        """Create a TopicGenerationService with mocked dependencies."""
+        svc = TopicGenerationService.__new__(TopicGenerationService)
+        svc._session = db_session
+        svc._repo = mock_repo
+        svc._interest_repo = mock_interest_repo
+        svc._llm = mock_llm
+        return svc
+
+    @pytest.mark.unit
+    async def test_uses_top_keywords_when_available(
+        self, service, mock_repo, mock_interest_repo
+    ):
+        """When top keywords exist, generates topics per keyword."""
+        count = await service.generate_common_topics()
+
+        mock_interest_repo.get_global_top_keywords.assert_called_once()
+        assert count == 3
+        assert mock_repo.create_suggestion.call_count == 3
+
+    @pytest.mark.unit
+    async def test_creates_suggestion_with_keyword_as_source(
+        self, service, mock_repo
+    ):
+        """Each created suggestion uses the keyword as source_keyword."""
+        await service.generate_common_topics()
+
+        calls = mock_repo.create_suggestion.call_args_list
+        source_keywords = [c.kwargs["source_keyword"] for c in calls]
+        assert source_keywords == ["sports", "technology", "music"]
+
+    @pytest.mark.unit
+    async def test_falls_back_to_trending_when_no_keywords(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """Falls back to LLM trending search when no keywords available."""
+        from coyo.services.llm.base import TextChunk
+
+        mock_interest_repo.get_global_top_keywords = AsyncMock(return_value=[])
+
+        # Override LLM to return 3 topics for the fallback path
+        async def mock_trending(messages, options=None):
+            yield TextChunk(text=_make_topic_json(3))
+
+        mock_llm.chat_with_tools = mock_trending
+
+        count = await service.generate_common_topics()
+
+        assert count == 3
+        assert mock_repo.create_suggestion.call_count == 3
+
+    @pytest.mark.unit
+    async def test_idempotent_when_already_generated(
+        self, service, mock_repo, mock_interest_repo
+    ):
+        """If topics already exist for today, skip generation and return count."""
+        mock_repo.get_common_suggestions = AsyncMock(
+            return_value=[_make_suggestion_mock() for _ in range(3)]
+        )
+        count = await service.generate_common_topics()
+
+        assert count == 3
+        mock_repo.create_suggestion.assert_not_called()
+        mock_interest_repo.get_global_top_keywords.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_handles_fetch_failure_gracefully(
+        self, service, mock_repo, mock_llm
+    ):
+        """If _fetch_personal_topic returns None for a keyword, it is skipped."""
+        from coyo.services.llm.base import TextChunk
+
+        call_count = 0
+
+        async def mock_chat_sometimes_fail(messages, options=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                # Return invalid JSON to cause parse failure
+                yield TextChunk(text="invalid json")
+            else:
+                yield TextChunk(text=_make_personal_topic_json())
+
+        mock_llm.chat_with_tools = mock_chat_sometimes_fail
+        # Also stub out structured fallback to fail
+        mock_llm.structured = AsyncMock(side_effect=Exception("structured failed"))
+
+        count = await service.generate_common_topics()
+
+        # 3 keywords attempted, 1 fails => 2 succeed
+        assert count == 2
+
+    @pytest.mark.unit
+    async def test_suggestion_pool_type_is_common(self, service, mock_repo):
+        """All created suggestions have pool_type='common'."""
+        await service.generate_common_topics()
+
+        for call in mock_repo.create_suggestion.call_args_list:
+            assert call.kwargs["pool_type"] == "common"
+
+    @pytest.mark.unit
+    async def test_suggestion_generated_date_is_today(self, service, mock_repo):
+        """All created suggestions have generated_date=today."""
+        await service.generate_common_topics()
+
+        for call in mock_repo.create_suggestion.call_args_list:
+            assert call.kwargs["generated_date"] == date.today()

--- a/apps/api/tests/unit/test_global_top_keywords.py
+++ b/apps/api/tests/unit/test_global_top_keywords.py
@@ -1,0 +1,136 @@
+"""Unit tests for InterestRepository.get_global_top_keywords."""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.user import AuthProvider, User
+from coyo.models.user_interest import UserInterest
+from coyo.repositories.interest import InterestRepository
+
+
+async def _create_user(db_session: AsyncSession, suffix: str) -> User:
+    """Create a unique test user."""
+    user = User(
+        auth_uid=f"test-uid-{suffix}",
+        email=f"user-{suffix}@example.com",
+        auth_provider=AuthProvider.EMAIL,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+async def _create_interest(
+    db_session: AsyncSession,
+    user_id: uuid.UUID,
+    keyword: str,
+    *,
+    keyword_type: str = "category",
+    is_news_relevant: bool = True,
+) -> UserInterest:
+    """Create a UserInterest record."""
+    interest = UserInterest(
+        user_id=user_id,
+        keyword=keyword,
+        keyword_type=keyword_type,
+        is_news_relevant=is_news_relevant,
+        total_mentions=1,
+        short_term_stored=1.0,
+        last_mentioned_conv_idx=1,
+    )
+    db_session.add(interest)
+    await db_session.flush()
+    return interest
+
+
+class TestGetGlobalTopKeywords:
+    """Tests for get_global_top_keywords repository method."""
+
+    @pytest.mark.unit
+    async def test_returns_keywords_ordered_by_user_count_desc(
+        self, db_session: AsyncSession
+    ):
+        """Keywords with more distinct users rank higher."""
+        user1 = await _create_user(db_session, "a")
+        user2 = await _create_user(db_session, "b")
+        user3 = await _create_user(db_session, "c")
+
+        # "sports" -> 3 users, "tech" -> 1 user, "music" -> 2 users
+        await _create_interest(db_session, user1.id, "sports")
+        await _create_interest(db_session, user2.id, "sports")
+        await _create_interest(db_session, user3.id, "sports")
+        await _create_interest(db_session, user1.id, "tech")
+        await _create_interest(db_session, user1.id, "music")
+        await _create_interest(db_session, user2.id, "music")
+        await db_session.commit()
+
+        repo = InterestRepository(db_session)
+        result = await repo.get_global_top_keywords(limit=3)
+
+        assert result == ["sports", "music", "tech"]
+
+    @pytest.mark.unit
+    async def test_filters_by_keyword_type(self, db_session: AsyncSession):
+        """Only returns keywords matching the keyword_type filter."""
+        user1 = await _create_user(db_session, "d")
+
+        await _create_interest(
+            db_session, user1.id, "tennis", keyword_type="entity"
+        )
+        await _create_interest(
+            db_session, user1.id, "sports", keyword_type="category"
+        )
+        await db_session.commit()
+
+        repo = InterestRepository(db_session)
+        result = await repo.get_global_top_keywords(keyword_type="category")
+
+        assert result == ["sports"]
+        assert "tennis" not in result
+
+    @pytest.mark.unit
+    async def test_filters_by_is_news_relevant(self, db_session: AsyncSession):
+        """Only returns keywords with is_news_relevant=True by default."""
+        user1 = await _create_user(db_session, "e")
+
+        await _create_interest(
+            db_session, user1.id, "cooking", is_news_relevant=False
+        )
+        await _create_interest(
+            db_session, user1.id, "politics", is_news_relevant=True
+        )
+        await db_session.commit()
+
+        repo = InterestRepository(db_session)
+        result = await repo.get_global_top_keywords()
+
+        assert result == ["politics"]
+        assert "cooking" not in result
+
+    @pytest.mark.unit
+    async def test_respects_limit_parameter(self, db_session: AsyncSession):
+        """Returns at most `limit` keywords."""
+        user1 = await _create_user(db_session, "f")
+        user2 = await _create_user(db_session, "g")
+
+        for kw in ["sports", "music", "tech", "politics"]:
+            await _create_interest(db_session, user1.id, kw)
+            await _create_interest(db_session, user2.id, kw)
+        await db_session.commit()
+
+        repo = InterestRepository(db_session)
+        result = await repo.get_global_top_keywords(limit=2)
+
+        assert len(result) == 2
+
+    @pytest.mark.unit
+    async def test_returns_empty_list_when_no_interests(
+        self, db_session: AsyncSession
+    ):
+        """Returns empty list when no interests exist in the database."""
+        repo = InterestRepository(db_session)
+        result = await repo.get_global_top_keywords()
+
+        assert result == []

--- a/apps/api/tests/unit/test_resolve_topic_keyword.py
+++ b/apps/api/tests/unit/test_resolve_topic_keyword.py
@@ -1,0 +1,206 @@
+"""Unit tests for MemoryExtractionService._resolve_topic_keyword."""
+
+import uuid
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.conversation import Conversation
+from coyo.services.memory_extraction import MemoryExtractionService
+
+
+@pytest.fixture(autouse=True)
+def _mock_embedding_service() -> Generator[MagicMock, None, None]:
+    """Stub get_embedding_service so tests never hit the real OpenAI API."""
+    fake_service = MagicMock()
+
+    async def _embed(texts: list[str]) -> list[list[float]]:
+        return [[0.0] * 1536 for _ in texts]
+
+    fake_service.embed = AsyncMock(side_effect=_embed)
+    with patch(
+        "coyo.services.embedding.get_embedding_service",
+        return_value=fake_service,
+    ):
+        yield fake_service
+
+
+def _make_conversation(
+    *,
+    topic: str | None = None,
+    topic_suggestion_id: uuid.UUID | None = None,
+) -> Conversation:
+    """Build a minimal Conversation with topic fields set."""
+    conv = MagicMock(spec=Conversation)
+    conv.topic = topic
+    conv.topic_suggestion_id = topic_suggestion_id
+    return conv
+
+
+class TestResolveTopicKeyword:
+    """Tests for _resolve_topic_keyword static method."""
+
+    @pytest.mark.unit
+    async def test_suggested_topic_returns_source_keyword(
+        self, db_session: AsyncSession
+    ):
+        """Suggested topic (topic_suggestion_id set) returns (source_keyword, None)."""
+        suggestion_id = uuid.uuid4()
+        conv = _make_conversation(
+            topic="suggested", topic_suggestion_id=suggestion_id
+        )
+
+        mock_suggestion = MagicMock()
+        mock_suggestion.source_keyword = "  NBA  "
+
+        with patch.object(db_session, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_suggestion
+
+            keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+                db_session, conv
+            )
+
+        assert keyword == "nba"
+        assert iab_id is None
+
+    @pytest.mark.unit
+    async def test_fixed_topic_business_returns_iab_mapping(
+        self, db_session: AsyncSession
+    ):
+        """Fixed topic 'business' returns ('business and finance', '52')."""
+        conv = _make_conversation(topic="business")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "business and finance"
+        assert iab_id == "52"
+
+    @pytest.mark.unit
+    async def test_fixed_topic_sports_returns_iab_mapping(
+        self, db_session: AsyncSession
+    ):
+        """Fixed topic 'sports' returns ('sports', '483')."""
+        conv = _make_conversation(topic="sports")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "sports"
+        assert iab_id == "483"
+
+    @pytest.mark.unit
+    async def test_fixed_topic_technology_returns_iab_mapping(
+        self, db_session: AsyncSession
+    ):
+        """Fixed topic 'technology' returns ('technology & computing', '596')."""
+        conv = _make_conversation(topic="technology")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "technology & computing"
+        assert iab_id == "596"
+
+    @pytest.mark.unit
+    async def test_fixed_topic_politics_returns_iab_mapping(
+        self, db_session: AsyncSession
+    ):
+        """Fixed topic 'politics' returns ('politics', '386')."""
+        conv = _make_conversation(topic="politics")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "politics"
+        assert iab_id == "386"
+
+    @pytest.mark.unit
+    async def test_fixed_topic_entertainment_returns_iab_mapping(
+        self, db_session: AsyncSession
+    ):
+        """Fixed topic 'entertainment' returns ('entertainment', 'JLBCU7')."""
+        conv = _make_conversation(topic="entertainment")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "entertainment"
+        assert iab_id == "JLBCU7"
+
+    @pytest.mark.unit
+    async def test_suggested_topic_without_suggestion_id_returns_none(
+        self, db_session: AsyncSession
+    ):
+        """topic='suggested' with no topic_suggestion_id returns (None, None)."""
+        conv = _make_conversation(topic="suggested")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword is None
+        assert iab_id is None
+
+    @pytest.mark.unit
+    async def test_none_topic_returns_none(self, db_session: AsyncSession):
+        """topic=None returns (None, None)."""
+        conv = _make_conversation(topic=None)
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword is None
+        assert iab_id is None
+
+    @pytest.mark.unit
+    async def test_unknown_fixed_topic_returns_none(self, db_session: AsyncSession):
+        """An unknown topic key (not in _FIXED_TOPIC_IAB) returns (None, None)."""
+        conv = _make_conversation(topic="cooking")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword is None
+        assert iab_id is None
+
+    @pytest.mark.unit
+    async def test_suggested_topic_with_missing_suggestion_returns_none(
+        self, db_session: AsyncSession
+    ):
+        """topic_suggestion_id set but suggestion not found in DB returns (None, None)."""
+        suggestion_id = uuid.uuid4()
+        conv = _make_conversation(
+            topic="suggested", topic_suggestion_id=suggestion_id
+        )
+
+        with patch.object(db_session, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+
+            keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+                db_session, conv
+            )
+
+        assert keyword is None
+        assert iab_id is None
+
+    @pytest.mark.unit
+    async def test_fixed_topic_case_insensitive(self, db_session: AsyncSession):
+        """Fixed topic lookup is case-insensitive."""
+        conv = _make_conversation(topic="SPORTS")
+
+        keyword, iab_id = await MemoryExtractionService._resolve_topic_keyword(
+            db_session, conv
+        )
+
+        assert keyword == "sports"
+        assert iab_id == "483"

--- a/apps/api/tests/unit/test_topic_generation.py
+++ b/apps/api/tests/unit/test_topic_generation.py
@@ -8,8 +8,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from coyo.services.topic_generation import TopicGenerationService, TopicSearchResult
-
+from coyo.services.topic_generation import TopicGenerationService
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,6 +54,15 @@ class TestGenerateCommonTopics:
         return repo
 
     @pytest.fixture
+    def mock_interest_repo(self):
+        """Create a mock InterestRepository."""
+        repo = AsyncMock()
+        repo.get_global_top_keywords = AsyncMock(
+            return_value=["tennis", "baseball", "politics"]
+        )
+        return repo
+
+    @pytest.fixture
     def mock_llm(self):
         """Create a mock OpenAIClient that returns valid topic JSON via chat_with_tools."""
         from coyo.services.llm.base import TextChunk
@@ -69,17 +77,27 @@ class TestGenerateCommonTopics:
         return mock
 
     @pytest.fixture
-    def service(self, db_session: AsyncSession, mock_repo, mock_llm):
+    def service(self, db_session: AsyncSession, mock_repo, mock_interest_repo, mock_llm):
         """Create a TopicGenerationService with mocked dependencies."""
         svc = TopicGenerationService.__new__(TopicGenerationService)
         svc._session = db_session
         svc._repo = mock_repo
+        svc._interest_repo = mock_interest_repo
         svc._llm = mock_llm
         return svc
 
     @pytest.mark.unit
-    async def test_generates_topics_and_returns_count(self, service, mock_repo):
-        count = await service.generate_common_topics()
+    async def test_generates_topics_from_keywords_and_returns_count(
+        self, service, mock_repo
+    ):
+        """Uses top keywords from user interests to generate topics."""
+        from coyo.services.topic_generation import PersonalTopicItem
+
+        mock_topic = PersonalTopicItem(
+            title="Test", summary="Test", article_content="Content"
+        )
+        with patch.object(service, "_fetch_personal_topic", return_value=mock_topic):
+            count = await service.generate_common_topics()
         assert count == 3
         assert mock_repo.create_suggestion.call_count == 3
 
@@ -94,14 +112,11 @@ class TestGenerateCommonTopics:
         mock_repo.create_suggestion.assert_not_called()
 
     @pytest.mark.unit
-    async def test_limits_to_max_topics(self, service, mock_repo, mock_llm):
-        """Even if LLM returns more than 3 topics, only 3 are created."""
-        from coyo.services.llm.base import TextChunk
-
-        async def many_topics(messages, options=None):
-            yield TextChunk(text=_make_topic_json(5))
-
-        mock_llm.chat_with_tools = many_topics
+    async def test_falls_back_to_trending_when_no_keywords(
+        self, service, mock_repo, mock_interest_repo, mock_llm
+    ):
+        """Falls back to LLM trending search when no keywords exist."""
+        mock_interest_repo.get_global_top_keywords = AsyncMock(return_value=[])
         count = await service.generate_common_topics()
         assert count == 3
         assert mock_repo.create_suggestion.call_count == 3
@@ -109,6 +124,8 @@ class TestGenerateCommonTopics:
     @pytest.mark.unit
     async def test_handles_save_error_gracefully(self, service, mock_repo):
         """If one topic fails to save with IntegrityError, others still proceed."""
+        from coyo.services.topic_generation import PersonalTopicItem
+
         call_count = 0
 
         async def create_with_error(**kwargs):
@@ -119,17 +136,28 @@ class TestGenerateCommonTopics:
             return _make_suggestion_mock()
 
         mock_repo.create_suggestion = create_with_error
-        count = await service.generate_common_topics()
+        mock_topic = PersonalTopicItem(
+            title="Test", summary="Test", article_content="Content"
+        )
+        with patch.object(service, "_fetch_personal_topic", return_value=mock_topic):
+            count = await service.generate_common_topics()
         assert count == 2  # 1st and 3rd succeed
 
     @pytest.mark.unit
-    async def test_calls_create_suggestion_with_correct_args(self, service, mock_repo):
-        await service.generate_common_topics()
+    async def test_calls_create_suggestion_with_keyword_as_source(
+        self, service, mock_repo
+    ):
+        """source_keyword should be the interest keyword, not LLM-generated."""
+        from coyo.services.topic_generation import PersonalTopicItem
+
+        mock_topic = PersonalTopicItem(
+            title="Tennis News", summary="Latest", article_content="Content"
+        )
+        with patch.object(service, "_fetch_personal_topic", return_value=mock_topic):
+            await service.generate_common_topics()
         first_call = mock_repo.create_suggestion.call_args_list[0]
         kwargs = first_call.kwargs
-        assert kwargs["title"] == "Topic 0"
-        assert kwargs["summary"] == "Summary 0"
-        assert kwargs["source_keyword"] == "kw0"
+        assert kwargs["source_keyword"] == "tennis"
         assert kwargs["pool_type"] == "common"
         assert kwargs["generated_date"] == date.today()
 

--- a/apps/api/tests/unit/test_upsert_topic_keyword.py
+++ b/apps/api/tests/unit/test_upsert_topic_keyword.py
@@ -1,0 +1,171 @@
+"""Unit tests for MemoryExtractionService._upsert_topic_keyword."""
+
+import uuid
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from coyo.models.conversation import Conversation
+from coyo.models.user import User
+from coyo.repositories.interest import InterestRepository
+from coyo.services.memory_extraction import MemoryExtractionService
+
+
+@pytest.fixture(autouse=True)
+def _mock_embedding_service() -> Generator[MagicMock, None, None]:
+    """Stub get_embedding_service so tests never hit the real OpenAI API."""
+    fake_service = MagicMock()
+
+    async def _embed(texts: list[str]) -> list[list[float]]:
+        return [[0.0] * 1536 for _ in texts]
+
+    fake_service.embed = AsyncMock(side_effect=_embed)
+    with patch(
+        "coyo.services.embedding.get_embedding_service",
+        return_value=fake_service,
+    ) as _:
+        yield fake_service
+
+
+def _make_conversation(
+    *,
+    topic: str | None = None,
+    topic_suggestion_id: uuid.UUID | None = None,
+) -> Conversation:
+    """Build a minimal Conversation mock."""
+    conv = MagicMock(spec=Conversation)
+    conv.topic = topic
+    conv.topic_suggestion_id = topic_suggestion_id
+    return conv
+
+
+class TestUpsertTopicKeyword:
+    """Tests for _upsert_topic_keyword static method."""
+
+    @pytest.mark.unit
+    async def test_skipped_when_keyword_already_in_seen(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """Topic keyword already in seen_keywords -> no upsert call."""
+        conv = _make_conversation(topic="sports")
+        repo = AsyncMock(spec=InterestRepository)
+        seen = {"sports"}
+
+        await MemoryExtractionService._upsert_topic_keyword(
+            db_session, repo, test_user.id, 1, conv, seen
+        )
+
+        repo.upsert_interest.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_skipped_when_no_topic_resolved(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """No topic keyword resolved (topic=None) -> no upsert call."""
+        conv = _make_conversation(topic=None)
+        repo = AsyncMock(spec=InterestRepository)
+        seen: set[str] = set()
+
+        await MemoryExtractionService._upsert_topic_keyword(
+            db_session, repo, test_user.id, 1, conv, seen
+        )
+
+        repo.upsert_interest.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_existing_interest_uses_existing_news_relevant(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """When keyword exists in DB, upserts with existing is_news_relevant value."""
+        conv = _make_conversation(topic="sports")
+        repo = AsyncMock(spec=InterestRepository)
+        seen: set[str] = set()
+
+        # Mock the existing interest lookup
+        existing_interest = MagicMock()
+        existing_interest.is_news_relevant = False
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_interest
+
+        with patch.object(
+            db_session, "execute", new_callable=AsyncMock, return_value=mock_result
+        ):
+            await MemoryExtractionService._upsert_topic_keyword(
+                db_session, repo, test_user.id, 1, conv, seen
+            )
+
+        repo.upsert_interest.assert_called_once()
+        call_kwargs = repo.upsert_interest.call_args.kwargs
+        assert call_kwargs["keyword"] == "sports"
+        assert call_kwargs["is_news_relevant"] is False
+        assert call_kwargs["embedding"] is None  # existing -> no embedding
+        assert "sports" in seen
+
+    @pytest.mark.unit
+    async def test_new_keyword_computes_embedding(
+        self, db_session: AsyncSession, test_user: User, _mock_embedding_service
+    ):
+        """When keyword is new (not in DB), computes embedding before upsert."""
+        conv = _make_conversation(topic="sports")
+        repo = AsyncMock(spec=InterestRepository)
+        seen: set[str] = set()
+
+        # No existing interest
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        with patch.object(
+            db_session, "execute", new_callable=AsyncMock, return_value=mock_result
+        ):
+            await MemoryExtractionService._upsert_topic_keyword(
+                db_session, repo, test_user.id, 1, conv, seen
+            )
+
+        repo.upsert_interest.assert_called_once()
+        call_kwargs = repo.upsert_interest.call_args.kwargs
+        assert call_kwargs["keyword"] == "sports"
+        assert call_kwargs["keyword_type"] == "category"
+        assert call_kwargs["is_news_relevant"] is True  # default for new
+        assert call_kwargs["iab_category_id"] == "483"
+        assert call_kwargs["embedding"] is not None
+        assert len(call_kwargs["embedding"]) == 1536
+        assert "sports" in seen
+
+    @pytest.mark.unit
+    async def test_adds_keyword_to_seen_set(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """After successful upsert, keyword is added to seen_keywords."""
+        conv = _make_conversation(topic="business")
+        repo = AsyncMock(spec=InterestRepository)
+        seen: set[str] = set()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        with patch.object(
+            db_session, "execute", new_callable=AsyncMock, return_value=mock_result
+        ):
+            await MemoryExtractionService._upsert_topic_keyword(
+                db_session, repo, test_user.id, 1, conv, seen
+            )
+
+        assert "business and finance" in seen
+
+    @pytest.mark.unit
+    async def test_skipped_when_suggested_topic_without_id(
+        self, db_session: AsyncSession, test_user: User
+    ):
+        """topic='suggested' with no topic_suggestion_id -> skipped."""
+        conv = _make_conversation(topic="suggested")
+        repo = AsyncMock(spec=InterestRepository)
+        seen: set[str] = set()
+
+        await MemoryExtractionService._upsert_topic_keyword(
+            db_session, repo, test_user.id, 1, conv, seen
+        )
+
+        repo.upsert_interest.assert_not_called()


### PR DESCRIPTION
## Summary
- When a conversation ends, the selected topic's keyword is now upserted as a user interest, bypassing the postprocessor pipeline (topic keywords are already processed or known IAB Tier 1 categories)
- Fixed topics (sports, business, etc.) are mapped to IAB Content Taxonomy v3.1 Tier 1 category names and IDs
- Common topics generation now selects the top 3 keywords from `user_interests` by distinct user count, instead of asking the LLM for arbitrary trending news (with cold-start fallback to original LLM search)
- Added `topic` column to `conversations` table to persist the selected topic key

## Test plan
- [x] Unit tests: 651 passed (including 29 new tests for topic keyword resolution, upsert, global keywords, and common topics generation)
- [x] Integration tests: 77 passed
- [x] Manual test: fixed topic (sports) → `user_interests` entry with `iab_category_id=483`
- [x] Manual test: suggested topic → `source_keyword` upserted as interest
- [x] Manual test: LLM extracts same keyword → no double-count (`seen_keywords` dedup)
- [x] Code review: approved
- [x] Security review: approved (0 blocking issues)
- [x] Python review: approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)