### PR TITLE
fix(mobile): guard sign-out and fix home scroll overlap (#157)

### DIFF
--- a/apps/mobile/e2e/helpers/sign-out.yaml
+++ b/apps/mobile/e2e/helpers/sign-out.yaml
@@ -12,6 +12,39 @@ appId: to.coyo.app
 - tapOn:
     id: "sign-out-button"
 
+# Wait for the confirmation Alert to finish animating in before the
+# conditional runFlow blocks below evaluate their visibility predicates
+# — without this, the first `when: visible` can short-circuit against a
+# half-rendered Alert and silently skip all three branches.
+- waitForAnimationToEnd
+
+# Confirm sign-out in the native Alert.
+# On Android, native AlertDialog auto-uppercases ("SIGN OUT" — unique on screen).
+# On iOS, the button is "Sign Out" (same label as the trigger button, so use index: 1).
+- runFlow:
+    when:
+      visible: "SIGN OUT"
+    commands:
+      - tapOn: "SIGN OUT"
+- runFlow:
+    when:
+      visible:
+        text: "Sign Out"
+        index: 1
+    commands:
+      - tapOn:
+          text: "Sign Out"
+          index: 1
+- runFlow:
+    when:
+      visible:
+        text: "サインアウト"
+        index: 1
+    commands:
+      - tapOn:
+          text: "サインアウト"
+          index: 1
+
 # Wait for the Welcome screen to appear after sign-out
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/e2e/voice-conversation.yaml
+++ b/apps/mobile/e2e/voice-conversation.yaml
@@ -30,21 +30,35 @@ appId: to.coyo.app
       id: "home-greeting"
     timeout: 30000
 
-# Scroll to the Sports topic card. With suggestions now reliably populated
-# above the fold (see suggestions-store.ts), Sports may be pushed further
-# down — use scrollUntilVisible instead of a fixed swipe distance.
+# Scroll to the Sports topic card. With suggestions populated above the
+# fold (see suggestions-store.ts), Sports is pushed further down. The
+# previous `scrollUntilVisible` raced the suggestions render: when the
+# trending section landed mid-scroll the element coordinates Maestro
+# resolved for `topic-sports` no longer matched its post-layout position,
+# and the tap landed on the sign-out button at the screen bottom (issue
+# #157). `waitForAnimationToEnd` after the scroll lets layout settle
+# before the tap is dispatched.
 - scrollUntilVisible:
     element:
       id: "topic-sports"
     direction: DOWN
     speed: 40
+    # Center the card in the viewport. iOS accessibility reports element
+    # bounds in screen coordinates, ignoring ScrollView clipping. Without
+    # `centerElement`, Maestro stops scrolling as soon as the card's
+    # rectangle intersects the screen — which on a narrow viewport leaves
+    # the card visually overlapping the sign-out button at the bottom,
+    # and the tap lands on Sign Out instead of Sports (issue #157).
+    centerElement: true
+- waitForAnimationToEnd
 
 - tapOn:
     id: "topic-sports"
+- waitForAnimationToEnd
 
 - extendedWaitUntil:
     visible:
-      text: "Coyo"
+      id: "end-conversation"
     timeout: 15000
 
 - assertVisible:
@@ -185,6 +199,17 @@ appId: to.coyo.app
     id: "go-home"
 
 - waitForAnimationToEnd
+
+# Home preserves the ScrollView's scroll position across navigation (the
+# HomeScreen component is kept mounted by the native stack). After the
+# Sports card was centered during scrollUntilVisible, the greeting is
+# now above the fold — scroll back to the top before asserting.
+- scrollUntilVisible:
+    element:
+      id: "home-greeting"
+    direction: UP
+    speed: 40
+    timeout: 10000
 
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -115,6 +115,33 @@ export function HomeScreen({ navigation }: Props) {
   const setPausedConversationId = useAppStore((s) => s.setPausedConversationId);
   const handleSignOut = useAuthStore((s) => s.handleSignOut);
 
+  // Sign-out is a destructive action that wipes the local session. The
+  // raw Pressable used to call `handleSignOut` directly, which made it
+  // possible for an unintended tap (e.g. a fast scroll-then-tap that
+  // landed on the button mid-layout) to drop the user back to Welcome
+  // mid-flow — see issue #157. Routing through a confirmation Alert
+  // both surfaces standard intent for users and prevents accidental
+  // taps from gesture-driven test runners.
+  const confirmSignOut = useCallback(() => {
+    Alert.alert(
+      t('home.signOutConfirm.title'),
+      t('home.signOutConfirm.message'),
+      [
+        { text: t('home.signOutConfirm.cancel'), style: 'cancel' },
+        {
+          text: t('home.signOutConfirm.confirm'),
+          style: 'destructive',
+          onPress: () => {
+            handleSignOut().catch(() => {
+              // handleSignOut surfaces its own error message via the auth
+              // store; the rejection is observed for telemetry only.
+            });
+          },
+        },
+      ],
+    );
+  }, [handleSignOut]);
+
   const topics = useMemo(() => getTopics(), []);
   const { suggestions } = useSuggestions();
 
@@ -222,7 +249,7 @@ export function HomeScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} testID="home-scroll-view">
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} testID="home-scroll-view">
         {/* Header area */}
         <View style={styles.header}>
           <View style={styles.headerRow}>
@@ -312,7 +339,7 @@ export function HomeScreen({ navigation }: Props) {
       {/* Sign out */}
       <Pressable
         style={styles.signOutContainer}
-        onPress={handleSignOut}
+        onPress={confirmSignOut}
         accessibilityRole="button"
         accessibilityLabel={t('home.signOut')}
         testID="sign-out-button"
@@ -329,6 +356,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.surfacePrimary,
+  },
+  // ScrollView must explicitly claim flex: 1 so it shares vertical space
+  // with the fixed sign-out button below it.
+  scrollView: {
+    flex: 1,
   },
   scrollContent: {
     paddingBottom: 20,

--- a/apps/mobile/src/features/home/__tests__/HomeScreen.signout.test.tsx
+++ b/apps/mobile/src/features/home/__tests__/HomeScreen.signout.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Sign-out confirmation behaviour for HomeScreen (issue #157).
+ *
+ * The sign-out button used to call `handleSignOut` directly on press,
+ * which made it possible for an unintended tap (e.g. a fast scroll-then-
+ * tap that landed on the button) to drop the user back to Welcome
+ * mid-flow. The button now opens a native confirmation Alert and only
+ * calls `handleSignOut` after the user explicitly confirms.
+ */
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { HomeScreen } from '@/features/home/HomeScreen';
+
+// Heavy native deps — stub at the boundary so the test stays focused on
+// the button-press handler without wiring up the real screen graph.
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    SafeAreaView: View,
+  };
+});
+
+const mockHandleSignOut = jest.fn().mockResolvedValue(undefined);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Selector = (state: any) => unknown;
+
+jest.mock('@/stores/auth-store', () => ({
+  useAuthStore: (selector: Selector) => selector({ handleSignOut: mockHandleSignOut }),
+}));
+
+jest.mock('@/stores/conversation-store', () => ({
+  useConversationStore: (selector: Selector) => selector({ startConversation: jest.fn() }),
+}));
+
+jest.mock('@/stores/app-store', () => ({
+  useAppStore: (selector: Selector) =>
+    selector({ pausedConversationId: null, setPausedConversationId: jest.fn() }),
+}));
+
+jest.mock('@/features/home/hooks/useSuggestions', () => ({
+  useSuggestions: () => ({
+    suggestions: { personal: [], trending: [] },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/api/client', () => ({
+  apiClient: { post: jest.fn(), get: jest.fn(), delete: jest.fn(), postStream: jest.fn() },
+}));
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+const route = { key: 'Home', name: 'Home', params: undefined };
+
+describe('HomeScreen sign-out confirmation (issue #157)', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockHandleSignOut.mockClear();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it('opens a confirmation Alert when the sign-out button is pressed', () => {
+    const { getByTestId } = render(<HomeScreen navigation={navigation as never} route={route as never} />);
+    fireEvent.press(getByTestId('sign-out-button'));
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(mockHandleSignOut).not.toHaveBeenCalled();
+  });
+
+  it('calls handleSignOut only when the destructive confirm action is invoked', () => {
+    const { getByTestId } = render(<HomeScreen navigation={navigation as never} route={route as never} />);
+    fireEvent.press(getByTestId('sign-out-button'));
+
+    const buttons = alertSpy.mock.calls[0][2] as Array<{ style?: string; onPress?: () => void }>;
+    const confirm = buttons.find((b) => b.style === 'destructive');
+    expect(confirm).toBeDefined();
+    confirm!.onPress?.();
+
+    expect(mockHandleSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the user signed in if the cancel action is invoked', () => {
+    const { getByTestId } = render(<HomeScreen navigation={navigation as never} route={route as never} />);
+    fireEvent.press(getByTestId('sign-out-button'));
+
+    const buttons = alertSpy.mock.calls[0][2] as Array<{ style?: string; onPress?: () => void }>;
+    const cancel = buttons.find((b) => b.style === 'cancel');
+    expect(cancel).toBeDefined();
+    // Cancel buttons typically have no onPress or a noop.
+    cancel!.onPress?.();
+
+    expect(mockHandleSignOut).not.toHaveBeenCalled();
+  });
+
+  it('swallows rejected handleSignOut without surfacing an unhandled rejection', async () => {
+    mockHandleSignOut.mockRejectedValueOnce(new Error('keychain unavailable'));
+    const { getByTestId } = render(<HomeScreen navigation={navigation as never} route={route as never} />);
+    fireEvent.press(getByTestId('sign-out-button'));
+
+    const buttons = alertSpy.mock.calls[0][2] as Array<{ style?: string; onPress?: () => void }>;
+    const confirm = buttons.find((b) => b.style === 'destructive');
+    // If the wrapper did not catch the rejection, this would surface as
+    // an unhandled promise rejection and fail the test.
+    await expect(
+      (async () => {
+        confirm!.onPress?.();
+        await Promise.resolve();
+      })(),
+    ).resolves.not.toThrow();
+
+    expect(mockHandleSignOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/i18n/locales/en.ts
+++ b/apps/mobile/src/i18n/locales/en.ts
@@ -17,6 +17,12 @@ const en = {
     trendingTopics: 'Trending Topics',
     otherTopics: 'Other Topics',
     signOut: 'Sign Out',
+    signOutConfirm: {
+      title: 'Sign out?',
+      message: 'You will need to sign in again to continue your practice.',
+      cancel: 'Cancel',
+      confirm: 'Sign Out',
+    },
   },
 
   // Topics

--- a/apps/mobile/src/i18n/locales/ja.ts
+++ b/apps/mobile/src/i18n/locales/ja.ts
@@ -17,6 +17,12 @@ const ja = {
     trendingTopics: '注目トピック',
     otherTopics: 'その他',
     signOut: 'サインアウト',
+    signOutConfirm: {
+      title: 'サインアウトしますか?',
+      message: '練習を続けるには、再度サインインが必要です。',
+      cancel: 'キャンセル',
+      confirm: 'サインアウト',
+    },
   },
 
   // Topics


### PR DESCRIPTION
Closes #157.

## Summary

- Root cause: Home's `ScrollView` had no `flex: 1`, so the bottom-most topic card rendered at y-positions that visually overlapped the fixed Sign Out button. Maestro's tap on `topic-sports` (bounds `[20,742][370,814]`) landed inside the Sign Out hit zone (`[0,752][390,810]`), which invoked `handleSignOut` and dropped the user back to Welcome mid-flow.
- `HomeScreen`: add `flex: 1` to the ScrollView and wrap the sign-out Pressable in a native `Alert` confirmation so a mis-tap (real user or test) cannot silently end the session.
- E2E: `voice-conversation.yaml` uses `centerElement: true` on `scrollUntilVisible` (iOS accessibility reports bounds in screen coords, ignoring ScrollView clipping) and scrolls back up to `home-greeting` before the final assertion (Home preserves its scroll position across navigation). `helpers/sign-out.yaml` taps the new confirmation button after `waitForAnimationToEnd`.
- i18n strings (en + ja) for the confirmation dialog.
- Unit tests cover the four Alert branches (open, confirm, cancel, rejected `handleSignOut`).

## Test plan

- [x] `voice-conversation.yaml` passes 3 consecutive times on iOS
- [x] `voice-conversation.yaml` passes on Android
- [x] `start-conversation.yaml` regression passes (shares the same topic-card tap path)
- [x] `npx jest` — 324 tests pass (25 suites)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)