### PR TITLE
perf(api): optimize OpenAI prompt caching and add usage observability

### DIFF
--- a/apps/api/src/coyo/services/correction.py
+++ b/apps/api/src/coyo/services/correction.py
@@ -45,7 +45,11 @@ class CorrectionAnalysis(BaseModel):
 
 # -- System prompt template ---------------------------------------------
 
-_CORRECTION_SYSTEM_PROMPT = """\
+# The prompt is split into a byte-stable static prefix and a dynamic suffix
+# (language + user_text) so OpenAI's prompt-prefix cache can reuse the prefix
+# across calls. Do NOT interpolate dynamic values into the prefix.
+
+_CORRECTION_SYSTEM_PROMPT_PREFIX = """\
 You are an English language correction assistant. \
 The input text is transcribed from a spoken English conversation, not written text. \
 Analyze it for genuine spoken-English errors only.
@@ -74,30 +78,41 @@ error, not the entire sentence. Include only 1-2 surrounding words for context.
 - For each item, also provide the full original sentence and the full corrected \
 sentence (with ALL corrections for that sentence applied).
 - Classify each error as one of: "grammar", "expression", "vocabulary".
-- Write all explanations in {correction_language_name}.
+- Write all explanations in the language specified below \
+(see "Explanation language").
 - If the text has no errors, set has_errors to false, corrected_text to the \
 original text, explanation to an empty string, and items to an empty list.
 
 You MUST respond with valid JSON matching this exact schema:
-{{
+{
   "has_errors": <boolean>,
   "corrected_text": "<string>",
   "explanation": "<string — overall explanation of corrections>",
   "items": [
-    {{
+    {
       "original": "<string>",
       "corrected": "<string>",
       "original_sentence": "<string>",
       "corrected_sentence": "<string>",
       "type": "<grammar|expression|vocabulary>",
       "explanation": "<string>"
-    }}
+    }
   ]
-}}
-
-User text to analyze:
-\"\"\"{user_text}\"\"\"\
+}\
 """
+
+
+def _build_correction_system_prompt(
+    correction_language_name: str,
+    user_text: str,
+) -> str:
+    """Compose the correction prompt: static prefix + dynamic suffix."""
+    return (
+        f"{_CORRECTION_SYSTEM_PROMPT_PREFIX}\n\n"
+        f"Explanation language: {correction_language_name}\n\n"
+        f'User text to analyze:\n"""{user_text}"""'
+    )
+
 
 _LANGUAGE_NAMES: dict[str, str] = {
     "ja": "Japanese",
@@ -156,7 +171,7 @@ class CorrectionService:
         )
 
         language_name = _LANGUAGE_NAMES.get(correction_language, correction_language)
-        system_content = _CORRECTION_SYSTEM_PROMPT.format(
+        system_content = _build_correction_system_prompt(
             correction_language_name=language_name,
             user_text=user_text,
         )

--- a/apps/api/src/coyo/services/llm/openai_client.py
+++ b/apps/api/src/coyo/services/llm/openai_client.py
@@ -21,6 +21,39 @@ from coyo.services.llm.base import (
 logger = structlog.get_logger()
 
 
+def _log_usage(model: str, method: str, usage: object) -> None:
+    """Emit a structured log of OpenAI token usage for cache observability.
+
+    Captures ``prompt_tokens_details.cached_tokens`` so cache-hit rate is
+    visible to downstream log pipelines. Best-effort — never raises.
+    """
+    try:
+        prompt_tokens = getattr(usage, "prompt_tokens", None) or getattr(
+            usage, "input_tokens", None
+        )
+        completion_tokens = getattr(usage, "completion_tokens", None) or getattr(
+            usage, "output_tokens", None
+        )
+        details = getattr(usage, "prompt_tokens_details", None) or getattr(
+            usage, "input_tokens_details", None
+        )
+        cached_tokens = getattr(details, "cached_tokens", None) if details is not None else None
+        cache_hit_ratio: float | None = None
+        if prompt_tokens and cached_tokens is not None:
+            cache_hit_ratio = round(cached_tokens / prompt_tokens, 4)
+        logger.info(
+            "openai_usage",
+            model=model,
+            method=method,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            cache_hit_ratio=cache_hit_ratio,
+        )
+    except Exception as exc:  # pragma: no cover — observability must not break calls
+        logger.warning("openai_usage_log_failed", error=str(exc))
+
+
 class OpenAIClient(LLMClient):
     """LLM client backed by the OpenAI API.
 
@@ -32,25 +65,34 @@ class OpenAIClient(LLMClient):
         self._client = AsyncOpenAI(api_key=settings.openai_api_key)
         self._model = model or settings.llm_conversation_model
 
-    async def chat(
+    async def chat(  # type: ignore[override]
         self,
         messages: list[ChatMessage],
         options: ChatOptions | None = None,
     ) -> AsyncIterator[str]:
         """Stream chat completion tokens from OpenAI.
 
-        Yields individual text tokens as they are generated.
+        Yields individual text tokens as they are generated. Final chunk
+        carries a ``usage`` field (via ``stream_options``) which we log
+        for prompt-cache visibility.
         """
         opts = options or ChatOptions()
         try:
-            stream = await self._client.chat.completions.create(
+            stream = await self._client.chat.completions.create(  # type: ignore[call-overload]
                 model=self._model,
                 messages=[{"role": m.role, "content": m.content} for m in messages],
                 temperature=opts.temperature,
                 max_completion_tokens=opts.max_tokens,
                 stream=True,
+                stream_options={"include_usage": True},
             )
             async for chunk in stream:
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    _log_usage(self._model, "chat", usage)
+                # Usage-only trailing chunk has no choices — skip safely.
+                if not chunk.choices:
+                    continue
                 delta = chunk.choices[0].delta
                 if delta.content is not None:
                     yield delta.content
@@ -80,7 +122,7 @@ class OpenAIClient(LLMClient):
 
         try:
             search_signalled = False
-            stream = self._client.responses.stream(
+            stream = self._client.responses.stream(  # type: ignore[call-overload]
                 model=self._model,
                 instructions=instructions or "",
                 input=input_messages,
@@ -103,11 +145,14 @@ class OpenAIClient(LLMClient):
                         delta = getattr(event, "delta", "")
                         if delta:
                             yield TextChunk(text=delta)
+                    elif event_type == "response.completed":
+                        final = getattr(event, "response", None)
+                        usage = getattr(final, "usage", None)
+                        if usage is not None:
+                            _log_usage(self._model, "chat_with_tools", usage)
         except Exception as exc:
             logger.error("openai_responses_api_error", error=str(exc))
-            raise ExternalServiceError(
-                "OpenAI", "Responses API stream failed"
-            ) from exc
+            raise ExternalServiceError("OpenAI", "Responses API stream failed") from exc
 
     async def structured[T: BaseModel](
         self,
@@ -125,13 +170,16 @@ class OpenAIClient(LLMClient):
             #       the OpenAI structured outputs API once stable.
             #       For now, instruct the model to return JSON matching
             #       the schema and parse manually.
-            response = await self._client.chat.completions.create(
+            response = await self._client.chat.completions.create(  # type: ignore[call-overload]
                 model=self._model,
                 messages=[{"role": m.role, "content": m.content} for m in messages],
                 temperature=opts.temperature,
                 max_completion_tokens=opts.max_tokens,
                 response_format={"type": "json_object"},
             )
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                _log_usage(self._model, "structured", usage)
             content = response.choices[0].message.content
             if content is None:
                 raise ExternalServiceError("OpenAI", "Empty response content")

--- a/apps/api/src/coyo/services/turn_orchestrator.py
+++ b/apps/api/src/coyo/services/turn_orchestrator.py
@@ -48,8 +48,12 @@ logger = structlog.get_logger()
 _STT_CONTEXT_TURN_COUNT = 4
 _STT_MAX_PROMPT_CHARS = 800
 
-_CONVERSATION_SYSTEM_PROMPT = """\
-You are a friendly English conversation partner. The current topic is {topic}.
+# System prompts below are structured as [static prefix] + [dynamic suffix]
+# so OpenAI's prompt-prefix cache can reuse the static portion across calls.
+# Never interpolate a dynamic value into the prefix block — it defeats caching.
+
+_CONVERSATION_SYSTEM_PROMPT_PREFIX = """\
+You are a friendly English conversation partner.
 Keep your responses natural, concise (2-3 sentences), and at an intermediate \
 English level.
 If the user makes a grammar mistake, don't correct them in the conversation — \
@@ -60,24 +64,39 @@ list facts. NEVER include URLs, links, citations, or source references.\
 """
 
 
-_GREETING_SYSTEM_PROMPT = """\
-You are a friendly English conversation partner named Coyo. The current topic is {topic}.
+_GREETING_SYSTEM_PROMPT_PREFIX = """\
+You are a friendly English conversation partner named Coyo.
 Generate a natural opening greeting to start the conversation. Keep it warm and inviting \
 (2-3 sentences). Include exactly one open-ended question about the topic to encourage the \
 user to respond. Speak at an intermediate English level.\
 """
 
-_SUGGESTED_GREETING_SYSTEM_PROMPT = """\
+_SUGGESTED_GREETING_SYSTEM_PROMPT_PREFIX = """\
 You are a friendly English conversation partner named Coyo.
 The user wants to discuss a trending topic they selected.
-
-Background information (use naturally in conversation, don't quote directly):
-{article_context}
-
 Since the user selected this topic, YOU start the conversation.
 Open with a natural, engaging question or comment about this topic.
 Keep it warm and inviting (2-3 sentences). Speak at an intermediate English level.\
 """
+
+
+def _build_conversation_system_prompt(topic: str) -> str:
+    """Compose the turn system prompt: static prefix + dynamic topic suffix."""
+    return f"{_CONVERSATION_SYSTEM_PROMPT_PREFIX}\n\nCurrent topic: {topic}"
+
+
+def _build_greeting_system_prompt(topic: str) -> str:
+    """Compose the greeting system prompt: static prefix + dynamic topic suffix."""
+    return f"{_GREETING_SYSTEM_PROMPT_PREFIX}\n\nCurrent topic: {topic}"
+
+
+def _build_suggested_greeting_system_prompt(article_context: str) -> str:
+    """Compose the suggested-greeting prompt with article context as suffix."""
+    return (
+        f"{_SUGGESTED_GREETING_SYSTEM_PROMPT_PREFIX}\n\n"
+        "Background information (use naturally in conversation, don't quote directly):\n"
+        f"{article_context}"
+    )
 
 
 def _make_event(event: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -263,11 +282,9 @@ class TurnOrchestrator:
 
         # Build messages: system prompt only (no user message)
         if article_context:
-            system_prompt = _SUGGESTED_GREETING_SYSTEM_PROMPT.format(
-                article_context=article_context,
-            )
+            system_prompt = _build_suggested_greeting_system_prompt(article_context)
         else:
-            system_prompt = _GREETING_SYSTEM_PROMPT.format(topic=topic)
+            system_prompt = _build_greeting_system_prompt(topic)
 
         # Build the theme-aware memory snapshot once per conversation and
         # persist it on the Conversation row. The turn path will read it
@@ -364,7 +381,7 @@ class TurnOrchestrator:
         user message.
         """
         topic_label = topic if topic != "suggested" else "a trending news topic"
-        system_prompt = _CONVERSATION_SYSTEM_PROMPT.format(topic=topic_label)
+        system_prompt = _build_conversation_system_prompt(topic_label)
 
         memory_context = await self._read_or_compute_memory_snapshot(
             conversation_id=conversation_id,

--- a/apps/api/tests/unit/test_correction.py
+++ b/apps/api/tests/unit/test_correction.py
@@ -65,6 +65,7 @@ class TestCorrectionService:
 
         # Verify the turn status was updated
         updated_turn = await db_session.get(Turn, test_turn.id)
+        assert updated_turn is not None
         assert updated_turn.correction_status == "has_corrections"
 
     @pytest.mark.unit
@@ -96,6 +97,7 @@ class TestCorrectionService:
 
         # Verify the turn status was updated to 'clean'
         updated_turn = await db_session.get(Turn, test_turn.id)
+        assert updated_turn is not None
         assert updated_turn.correction_status == "clean"
 
     @pytest.mark.unit
@@ -125,6 +127,7 @@ class TestCorrectionService:
 
         assert result is None
         updated_turn = await db_session.get(Turn, test_turn.id)
+        assert updated_turn is not None
         assert updated_turn.correction_status == "clean"
 
     @pytest.mark.unit
@@ -301,36 +304,34 @@ class TestCorrectionPromptContent:
     @pytest.mark.unit
     def test_prompt_mentions_transcribed_spoken_context(self):
         """Verify the prompt indicates input is transcribed spoken English."""
-        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+        from coyo.services.correction import (
+            _CORRECTION_SYSTEM_PROMPT_PREFIX as _CORRECTION_SYSTEM_PROMPT,
+        )
 
         prompt_lower = _CORRECTION_SYSTEM_PROMPT.lower()
         assert "transcribed" in prompt_lower, (
             "Prompt must mention that input is transcribed speech"
         )
-        assert "spoken" in prompt_lower, (
-            "Prompt must mention spoken English context"
-        )
+        assert "spoken" in prompt_lower, "Prompt must mention spoken English context"
 
     @pytest.mark.unit
     def test_prompt_accepts_natural_spoken_patterns(self):
         """Verify the prompt instructs to accept filler words, fragments, and contractions."""
-        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+        from coyo.services.correction import (
+            _CORRECTION_SYSTEM_PROMPT_PREFIX as _CORRECTION_SYSTEM_PROMPT,
+        )
 
         prompt_lower = _CORRECTION_SYSTEM_PROMPT.lower()
-        assert "filler" in prompt_lower, (
-            "Prompt must mention filler words as acceptable"
-        )
-        assert "fragment" in prompt_lower, (
-            "Prompt must mention sentence fragments as acceptable"
-        )
-        assert "contraction" in prompt_lower, (
-            "Prompt must mention contractions as acceptable"
-        )
+        assert "filler" in prompt_lower, "Prompt must mention filler words as acceptable"
+        assert "fragment" in prompt_lower, "Prompt must mention sentence fragments as acceptable"
+        assert "contraction" in prompt_lower, "Prompt must mention contractions as acceptable"
 
     @pytest.mark.unit
     def test_prompt_contains_json_schema_instruction(self):
         """Verify the prompt still includes the JSON output schema instruction."""
-        from coyo.services.correction import _CORRECTION_SYSTEM_PROMPT
+        from coyo.services.correction import (
+            _CORRECTION_SYSTEM_PROMPT_PREFIX as _CORRECTION_SYSTEM_PROMPT,
+        )
 
         assert "has_errors" in _CORRECTION_SYSTEM_PROMPT, (
             "Prompt must reference the has_errors JSON field"
@@ -338,6 +339,4 @@ class TestCorrectionPromptContent:
         assert "corrected_text" in _CORRECTION_SYSTEM_PROMPT, (
             "Prompt must reference the corrected_text JSON field"
         )
-        assert "items" in _CORRECTION_SYSTEM_PROMPT, (
-            "Prompt must reference the items JSON field"
-        )
+        assert "items" in _CORRECTION_SYSTEM_PROMPT, "Prompt must reference the items JSON field"

--- a/apps/api/tests/unit/test_greeting.py
+++ b/apps/api/tests/unit/test_greeting.py
@@ -13,8 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from coyo.models.conversation import Conversation
 from coyo.models.turn import Turn
 from coyo.schemas.conversation import GreetingRequest
-from coyo.services.turn_orchestrator import TurnOrchestrator, _GREETING_SYSTEM_PROMPT
-
+from coyo.services.turn_orchestrator import (
+    TurnOrchestrator,
+    _build_greeting_system_prompt,
+)
 
 # ---------------------------------------------------------------------------
 # GreetingRequest schema validation
@@ -51,17 +53,17 @@ class TestGreetingRequestSchema:
 
     @pytest.mark.unit
     def test_invalid_topic_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017 — validation raises ValidationError; broad assert kept for backward compat
             GreetingRequest(topic="cooking")
 
     @pytest.mark.unit
     def test_empty_topic_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017 — validation raises ValidationError; broad assert kept for backward compat
             GreetingRequest(topic="")
 
     @pytest.mark.unit
     def test_none_topic_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017 — validation raises ValidationError; broad assert kept for backward compat
             GreetingRequest(topic=None)
 
     @pytest.mark.unit
@@ -113,9 +115,7 @@ class TestProcessGreeting:
         return mock
 
     @pytest.fixture
-    def orchestrator(
-        self, db_session: AsyncSession, mock_llm, mock_tts, mock_turn_repo
-    ):
+    def orchestrator(self, db_session: AsyncSession, mock_llm, mock_tts, mock_turn_repo):
         """Create a TurnOrchestrator with mocked dependencies."""
         orch = TurnOrchestrator(db_session)
         orch._llm = mock_llm
@@ -124,10 +124,8 @@ class TestProcessGreeting:
         return orch
 
     @pytest.mark.unit
-    async def test_process_greeting_yields_expected_event_sequence(
-        self, orchestrator
-    ):
-        """Verify the event sequence: ai_response_chunk(s) -> ai_response_done -> tts_audio_url -> turn_complete."""
+    async def test_process_greeting_yields_expected_event_sequence(self, orchestrator):
+        """Verify event order: chunk(s) -> ai_response_done -> tts_audio_url -> turn_complete."""
         conversation_id = uuid.uuid4()
 
         events = []
@@ -163,9 +161,7 @@ class TestProcessGreeting:
         assert chunk_texts == ["Hello", "! ", "How are you?"]
 
     @pytest.mark.unit
-    async def test_process_greeting_ai_response_done_contains_full_text(
-        self, orchestrator
-    ):
+    async def test_process_greeting_ai_response_done_contains_full_text(self, orchestrator):
         """Verify that ai_response_done contains the concatenated full text."""
         conversation_id = uuid.uuid4()
 
@@ -199,9 +195,7 @@ class TestProcessGreeting:
         )
 
     @pytest.mark.unit
-    async def test_process_greeting_tts_audio_url_event(
-        self, orchestrator, mock_tts
-    ):
+    async def test_process_greeting_tts_audio_url_event(self, orchestrator, mock_tts):
         """Verify that the tts_audio_url event contains the TTS URL."""
         conversation_id = uuid.uuid4()
 
@@ -217,9 +211,7 @@ class TestProcessGreeting:
         mock_tts.synthesize.assert_called_once_with("Hello! How are you?")
 
     @pytest.mark.unit
-    async def test_process_greeting_commits_session(
-        self, orchestrator, db_session
-    ):
+    async def test_process_greeting_commits_session(self, orchestrator, db_session):
         """Verify that the session is committed after all steps."""
         conversation_id = uuid.uuid4()
 
@@ -234,9 +226,7 @@ class TestProcessGreeting:
         db_session.commit.assert_called_once()
 
     @pytest.mark.unit
-    async def test_process_greeting_uses_greeting_system_prompt(
-        self, orchestrator
-    ):
+    async def test_process_greeting_uses_greeting_system_prompt(self, orchestrator):
         """Verify that the greeting system prompt is used, not the conversation prompt."""
         conversation_id = uuid.uuid4()
         topic = "technology"
@@ -256,7 +246,7 @@ class TestProcessGreeting:
 
         assert len(captured_messages) == 1
         assert captured_messages[0].role == "system"
-        expected_prompt = _GREETING_SYSTEM_PROMPT.format(topic=topic)
+        expected_prompt = _build_greeting_system_prompt(topic)
         assert captured_messages[0].content == expected_prompt
 
     @pytest.mark.unit
@@ -331,9 +321,7 @@ class TestGreetingEndpoint:
         assert data["error"]["code"] == "INVALID_STATE"
 
     @pytest.mark.integration
-    async def test_greeting_rejects_invalid_topic(
-        self, client, test_conversation: Conversation
-    ):
+    async def test_greeting_rejects_invalid_topic(self, client, test_conversation: Conversation):
         """Greeting should return 422 for invalid topic."""
         response = await client.post(
             f"/api/conversations/{test_conversation.id}/greeting",
@@ -342,9 +330,7 @@ class TestGreetingEndpoint:
         assert response.status_code == 422
 
     @pytest.mark.integration
-    async def test_greeting_rejects_missing_topic(
-        self, client, test_conversation: Conversation
-    ):
+    async def test_greeting_rejects_missing_topic(self, client, test_conversation: Conversation):
         """Greeting should return 422 when topic is missing."""
         response = await client.post(
             f"/api/conversations/{test_conversation.id}/greeting",
@@ -371,9 +357,7 @@ class TestGreetingEndpoint:
         We mock the orchestrator to avoid calling real LLM/TTS services.
         The endpoint returns an SSE response, so we check the status code.
         """
-        with patch(
-            "coyo.routers.conversations.TurnOrchestrator"
-        ) as MockOrchestrator:
+        with patch("coyo.routers.conversations.TurnOrchestrator") as MockOrchestrator:
             mock_instance = MagicMock()
 
             async def mock_greeting(**kwargs):

--- a/apps/api/tests/unit/test_orchestrator_suggested.py
+++ b/apps/api/tests/unit/test_orchestrator_suggested.py
@@ -8,11 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from coyo.services.turn_orchestrator import (
     TurnOrchestrator,
-    _GREETING_SYSTEM_PROMPT,
-    _SUGGESTED_GREETING_SYSTEM_PROMPT,
-    _CONVERSATION_SYSTEM_PROMPT,
+    _build_greeting_system_prompt,
+    _build_suggested_greeting_system_prompt,
 )
-
 
 # ---------------------------------------------------------------------------
 # process_greeting with article_context
@@ -68,7 +66,8 @@ class TestProcessGreetingWithArticleContext:
         orchestrator._llm.chat = capture_chat
 
         async for _ in orchestrator.process_greeting(
-            conversation_id=uuid.uuid4(), user_id=uuid.uuid4(),
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
             topic="suggested",
             article_context=article_context,
         ):
@@ -76,9 +75,7 @@ class TestProcessGreetingWithArticleContext:
 
         assert len(captured_messages) == 1
         assert captured_messages[0].role == "system"
-        expected = _SUGGESTED_GREETING_SYSTEM_PROMPT.format(
-            article_context=article_context
-        )
+        expected = _build_suggested_greeting_system_prompt(article_context)
         assert captured_messages[0].content == expected
 
     @pytest.mark.unit
@@ -93,13 +90,14 @@ class TestProcessGreetingWithArticleContext:
         orchestrator._llm.chat = capture_chat
 
         async for _ in orchestrator.process_greeting(
-            conversation_id=uuid.uuid4(), user_id=uuid.uuid4(),
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
             topic="sports",
         ):
             pass
 
         assert len(captured_messages) == 1
-        expected = _GREETING_SYSTEM_PROMPT.format(topic="sports")
+        expected = _build_greeting_system_prompt("sports")
         assert captured_messages[0].content == expected
 
     @pytest.mark.unit
@@ -107,7 +105,8 @@ class TestProcessGreetingWithArticleContext:
         """The event sequence should be correct even with article_context."""
         events = []
         async for event in orchestrator.process_greeting(
-            conversation_id=uuid.uuid4(), user_id=uuid.uuid4(),
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
             topic="suggested",
             article_context="Title: Test\n\nContent here.",
         ):
@@ -132,13 +131,14 @@ class TestProcessGreetingWithArticleContext:
 
         # Empty string is falsy, so it should use the regular prompt
         async for _ in orchestrator.process_greeting(
-            conversation_id=uuid.uuid4(), user_id=uuid.uuid4(),
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
             topic="technology",
             article_context="",
         ):
             pass
 
-        expected = _GREETING_SYSTEM_PROMPT.format(topic="technology")
+        expected = _build_greeting_system_prompt("technology")
         assert captured_messages[0].content == expected
 
 
@@ -212,9 +212,7 @@ class TestBuildMessagesWithSuggestedTopic:
         prev_ai.role = "ai"
         prev_ai.text = "Hello! Nice to meet you."
 
-        mock_turn_repo.get_by_conversation_id = AsyncMock(
-            return_value=[prev_user, prev_ai]
-        )
+        mock_turn_repo.get_by_conversation_id = AsyncMock(return_value=[prev_user, prev_ai])
 
         messages = await orchestrator._build_messages(
             uuid.uuid4(),

--- a/apps/api/tests/unit/test_prompt_caching.py
+++ b/apps/api/tests/unit/test_prompt_caching.py
@@ -1,0 +1,179 @@
+"""Tests covering prompt-cache optimizations.
+
+Two concerns:
+1. System prompts keep a byte-stable prefix across calls so OpenAI's
+   prompt-prefix cache can reuse it (dynamic values live in the suffix).
+2. ``OpenAIClient`` logs token usage including ``cached_tokens`` so cache
+   hit rate is observable.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from coyo.services.correction import (
+    _CORRECTION_SYSTEM_PROMPT_PREFIX,
+    _build_correction_system_prompt,
+)
+from coyo.services.llm.base import ChatMessage
+from coyo.services.llm.openai_client import OpenAIClient, _log_usage
+from coyo.services.turn_orchestrator import (
+    _CONVERSATION_SYSTEM_PROMPT_PREFIX,
+    _GREETING_SYSTEM_PROMPT_PREFIX,
+    _SUGGESTED_GREETING_SYSTEM_PROMPT_PREFIX,
+    _build_conversation_system_prompt,
+    _build_greeting_system_prompt,
+    _build_suggested_greeting_system_prompt,
+)
+
+# ---------------------------------------------------------------------------
+# Byte-stable prefix across dynamic values
+# ---------------------------------------------------------------------------
+
+
+class TestStablePrefix:
+    """Dynamic values must never mutate the cacheable static prefix."""
+
+    @pytest.mark.unit
+    def test_conversation_prefix_is_stable_across_topics(self):
+        p1 = _build_conversation_system_prompt("sports")
+        p2 = _build_conversation_system_prompt("technology")
+        prefix = _CONVERSATION_SYSTEM_PROMPT_PREFIX
+        assert p1.startswith(prefix)
+        assert p2.startswith(prefix)
+        assert p1 != p2  # dynamic suffix differs
+
+    @pytest.mark.unit
+    def test_greeting_prefix_is_stable_across_topics(self):
+        p1 = _build_greeting_system_prompt("sports")
+        p2 = _build_greeting_system_prompt("a trending news topic")
+        prefix = _GREETING_SYSTEM_PROMPT_PREFIX
+        assert p1.startswith(prefix)
+        assert p2.startswith(prefix)
+
+    @pytest.mark.unit
+    def test_suggested_greeting_prefix_is_stable_across_articles(self):
+        p1 = _build_suggested_greeting_system_prompt("Title A\n\nBody A.")
+        p2 = _build_suggested_greeting_system_prompt("Title B\n\nBody B.")
+        prefix = _SUGGESTED_GREETING_SYSTEM_PROMPT_PREFIX
+        assert p1.startswith(prefix)
+        assert p2.startswith(prefix)
+        assert p1 != p2
+
+    @pytest.mark.unit
+    def test_correction_prefix_is_stable_across_language_and_user_text(self):
+        p1 = _build_correction_system_prompt("Japanese", "I goed yesterday")
+        p2 = _build_correction_system_prompt("English", "He don't know")
+        prefix = _CORRECTION_SYSTEM_PROMPT_PREFIX
+        assert p1.startswith(prefix)
+        assert p2.startswith(prefix)
+        assert p1 != p2
+
+    @pytest.mark.unit
+    def test_correction_dynamic_values_live_in_suffix(self):
+        prompt = _build_correction_system_prompt("Japanese", "some spoken text")
+        suffix = prompt[len(_CORRECTION_SYSTEM_PROMPT_PREFIX) :]
+        assert "Japanese" in suffix
+        assert "some spoken text" in suffix
+        # And NOT in the prefix
+        assert "Japanese" not in _CORRECTION_SYSTEM_PROMPT_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# Usage logging
+# ---------------------------------------------------------------------------
+
+
+class TestUsageLogging:
+    """``_log_usage`` and the three client methods emit cache metrics."""
+
+    @pytest.mark.unit
+    def test_log_usage_computes_cache_hit_ratio(self):
+        import structlog
+
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=800),
+        )
+        with structlog.testing.capture_logs() as logs:
+            _log_usage("gpt-test", "chat", usage)
+
+        assert len(logs) == 1
+        entry = logs[0]
+        assert entry["event"] == "openai_usage"
+        assert entry["prompt_tokens"] == 1000
+        assert entry["cached_tokens"] == 800
+        assert entry["cache_hit_ratio"] == 0.8
+        assert entry["model"] == "gpt-test"
+        assert entry["method"] == "chat"
+
+    @pytest.mark.unit
+    def test_log_usage_handles_missing_details_gracefully(self):
+        usage = SimpleNamespace(prompt_tokens=100, completion_tokens=20)
+        _log_usage("gpt-test", "chat", usage)  # must not raise
+
+    @pytest.mark.unit
+    def test_log_usage_never_raises_on_malformed_usage(self):
+        # Intentionally wrong shape — observability must not break calls.
+        _log_usage("gpt-test", "chat", object())
+
+    @pytest.mark.unit
+    async def test_chat_requests_usage_in_stream(self):
+        """chat() must pass stream_options={'include_usage': True}."""
+        mock_client = MagicMock()
+
+        async def mock_stream():
+            if False:
+                yield  # empty async iter
+
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_stream())
+
+        with patch(
+            "coyo.services.llm.openai_client.AsyncOpenAI",
+            return_value=mock_client,
+        ):
+            client = OpenAIClient(model="gpt-test")
+            client._client = mock_client
+            async for _ in client.chat([ChatMessage(role="user", content="hi")]):
+                pass
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs.get("stream") is True
+        assert call_kwargs.get("stream_options") == {"include_usage": True}
+
+    @pytest.mark.unit
+    async def test_chat_logs_usage_from_trailing_chunk(self, caplog):
+        """Trailing usage-only chunk should be logged, not crash the iterator."""
+        mock_client = MagicMock()
+
+        # Simulate: one text chunk, then a usage-only trailing chunk.
+        text_chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+            usage=None,
+        )
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=500,
+                completion_tokens=10,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=384),
+            ),
+        )
+
+        async def mock_stream():
+            yield text_chunk
+            yield usage_chunk
+
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_stream())
+
+        with patch(
+            "coyo.services.llm.openai_client.AsyncOpenAI",
+            return_value=mock_client,
+        ):
+            client = OpenAIClient(model="gpt-test")
+            client._client = mock_client
+            tokens = [t async for t in client.chat([ChatMessage(role="user", content="hi")])]
+
+        assert tokens == ["Hi"]  # iterator did not crash on empty-choices chunk

--- a/apps/api/tests/unit/test_prompt_caching.py
+++ b/apps/api/tests/unit/test_prompt_caching.py
@@ -90,24 +90,22 @@ class TestUsageLogging:
 
     @pytest.mark.unit
     def test_log_usage_computes_cache_hit_ratio(self):
-        import structlog
-
         usage = SimpleNamespace(
             prompt_tokens=1000,
             completion_tokens=200,
             prompt_tokens_details=SimpleNamespace(cached_tokens=800),
         )
-        with structlog.testing.capture_logs() as logs:
+        with patch("coyo.services.llm.openai_client.logger") as mock_logger:
             _log_usage("gpt-test", "chat", usage)
 
-        assert len(logs) == 1
-        entry = logs[0]
-        assert entry["event"] == "openai_usage"
-        assert entry["prompt_tokens"] == 1000
-        assert entry["cached_tokens"] == 800
-        assert entry["cache_hit_ratio"] == 0.8
-        assert entry["model"] == "gpt-test"
-        assert entry["method"] == "chat"
+        mock_logger.info.assert_called_once()
+        call = mock_logger.info.call_args
+        assert call.args[0] == "openai_usage"
+        assert call.kwargs["prompt_tokens"] == 1000
+        assert call.kwargs["cached_tokens"] == 800
+        assert call.kwargs["cache_hit_ratio"] == 0.8
+        assert call.kwargs["model"] == "gpt-test"
+        assert call.kwargs["method"] == "chat"
 
     @pytest.mark.unit
     def test_log_usage_handles_missing_details_gracefully(self):

--- a/apps/mobile/e2e/helpers/sign-out.yaml
+++ b/apps/mobile/e2e/helpers/sign-out.yaml
@@ -19,31 +19,27 @@ appId: to.coyo.app
 - waitForAnimationToEnd
 
 # Confirm sign-out in the native Alert.
-# On Android, native AlertDialog auto-uppercases ("SIGN OUT" — unique on screen).
-# On iOS, the button is "Sign Out" (same label as the trigger button, so use index: 1).
+# The Home screen trigger button and the Alert's confirm button share the
+# same label ("Sign Out" / "サインアウト"). We disambiguate via Maestro's
+# `rightOf:` selector relative to the Alert's Cancel button — "Cancel" /
+# "キャンセル" only appears inside the Alert, and the confirm button is
+# always rendered to the right of Cancel on 2-button alerts on both iOS
+# and Android. Maestro text matching is case-insensitive so Android's
+# auto-uppercased "CANCEL" also matches "Cancel".
 - runFlow:
     when:
-      visible: "SIGN OUT"
-    commands:
-      - tapOn: "SIGN OUT"
-- runFlow:
-    when:
-      visible:
-        text: "Sign Out"
-        index: 1
+      visible: "Sign out?"
     commands:
       - tapOn:
           text: "Sign Out"
-          index: 1
+          rightOf: "Cancel"
 - runFlow:
     when:
-      visible:
-        text: "サインアウト"
-        index: 1
+      visible: "サインアウトしますか?"
     commands:
       - tapOn:
           text: "サインアウト"
-          index: 1
+          rightOf: "キャンセル"
 
 # Wait for the Welcome screen to appear after sign-out
 - extendedWaitUntil:


### PR DESCRIPTION
## Summary

- Split OpenAI system prompts (turn / greeting / suggested-greeting / correction) into byte-stable static prefixes + dynamic suffixes so the prompt-prefix cache can reuse the static portion across calls. Dynamic values (topic, language, user_text, article_context) that used to be interpolated into the prefix now live at the end of the prompt.
- Add \`cached_tokens\` / \`cache_hit_ratio\` / \`prompt_tokens\` / \`completion_tokens\` logging to \`OpenAIClient\` across all three call paths (\`chat\` streaming via \`stream_options.include_usage\`, \`chat_with_tools\` via Responses API \`response.completed\`, \`structured\` via non-streaming usage). Observability first — no blind optimization.
- Unify \`apps/mobile/e2e/helpers/sign-out.yaml\` across iOS and Android by replacing brittle \`index: 1\` text matching with \`rightOf: "Cancel"\` / \`rightOf: "キャンセル"\`. The trigger and Alert confirm buttons both read "Sign Out" / "サインアウト", but the Alert's Cancel label only appears inside the Alert, so it's a stable anchor. Fixes a preexisting iOS 26.2 flake that was unmasked when re-running E2E on this branch.

Closes #103

### Why

Per the OpenAI prompt caching guide, 1024+ token prompt prefixes reused across calls are cached at 50% cost / lower latency. Previously our prompts interpolated \`{topic}\` in the first sentence of every system prompt, which changed the cache key on every request. This PR keeps the static instruction block byte-identical and appends the dynamic bit at the end, making the prefix eligible for reuse. The logging lets us observe hit rate without further code changes — per user direction, we do NOT pad prompts to cross the 1024 threshold (would increase token cost for little gain).

## Test plan

- [x] Unit tests updated: \`test_correction.py\`, \`test_greeting.py\`, \`test_orchestrator_suggested.py\` (import new builders)
- [x] New \`test_prompt_caching.py\`: byte-stable prefix invariants + \`_log_usage\` + trailing-chunk handling
- [x] Full API pytest: 738 passing
- [x] mypy + ruff clean on all touched files
- [x] Parallel reviews: \`code-reviewer\`, \`security-reviewer\`, \`python-reviewer\` — all APPROVED
- [x] E2E iOS: 8/8 (auth-sign-in verified with new \`rightOf:\` selector actually executing the sign-out branch)
- [x] E2E Android: 8/8 (unified selector verified on sign-in-state run, not just clean-state skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)