### PR TITLE
fix: block bare uv run to prevent exclude-newer stripping from uv.lock

### DIFF
--- a/.claude/hooks/check-uv-install.sh
+++ b/.claude/hooks/check-uv-install.sh
@@ -23,12 +23,16 @@
 #     bash scripts/uv-install.sh ... → wrapper that injects --exclude-newer
 #     bash scripts/install-npm-pinned.sh
 #     uv sync --frozen ...           → restore from the lockfile
-#     uv venv / uv run / uv --version → no resolution, no cooldown needed
+#     uv run --frozen ...            → run without re-resolving
+#     uv venv / uv --version        → no resolution, no cooldown needed
+#     make api-test                  → uv run --frozen pytest
+#     make api-cmd CMD="..."         → uv run --frozen <arbitrary>
 #
 # What the hook blocks (each is a "common accident" Claude might emit):
 #     uv pip install / uv pip compile / uv pip sync / uv pip uninstall
 #     uv add / uv lock
 #     uv sync (without --frozen)
+#     uv run  (without --frozen) — silently strips exclude-newer from uv.lock
 #     uv tool install / uv tool run / uvx
 #     pip install (pip, pip3, python -m pip, python3 -m pip)
 #     bash -c / sh -c / eval / python -c   when the inner string mentions
@@ -139,6 +143,16 @@ if [[ "$command" =~ uv[[:space:]]+sync[^\&\|\;]* ]]; then
   fi
 fi
 
+# uv run (without --frozen). Same approach as uv sync: extract the segment,
+# strip comments, look for --frozen as a standalone token.
+if [[ "$command" =~ uv[[:space:]]+run[^\&\|\;]* ]]; then
+  uv_run_segment="${BASH_REMATCH[0]}"
+  uv_run_segment_clean="${uv_run_segment%%#*}"
+  if ! [[ "$uv_run_segment_clean" =~ (^|[[:space:]])--frozen([[:space:]=]|$) ]]; then
+    block "uv run without --frozen detected (use 'make api-test' or '.venv/bin/<cmd>' instead)"
+  fi
+fi
+
 # pip install in any of its forms.
 if [[ "$command" =~ ${LEAD}(python[23]?[[:space:]]+-m[[:space:]]+)?pip[23]?[[:space:]]+install ]]; then
   block "pip install detected"
@@ -154,12 +168,12 @@ fi
 # bash -c / sh -c with uv/pip inside the quoted string.
 # (\b word boundaries are not reliable in bash POSIX ERE on macOS, so we
 # rely on greedy `.*` + the explicit token shapes in the alternation.)
-if [[ "$command" =~ (bash|sh)[[:space:]]+-c[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
+if [[ "$command" =~ (bash|sh)[[:space:]]+-c[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|run|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
   block "indirect uv/pip via ${BASH_REMATCH[1]} -c detected"
 fi
 
 # eval with uv/pip inside the quoted string.
-if [[ "$command" =~ eval[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
+if [[ "$command" =~ eval[[:space:]]+[\"\'].*(uv[[:space:]]+(pip|add|lock|sync|run|tool)|uvx|pip[23]?[[:space:]]+install) ]]; then
   block "indirect uv/pip via eval detected"
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "apps/api/uv.lock"
       - run: uv sync --frozen --extra dev
-      - run: uv run ruff check src/
+      - run: uv run --frozen ruff check src/
 
   lint-mobile:
     name: Lint Mobile
@@ -157,7 +157,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "apps/api/uv.lock"
       - run: uv sync --frozen --extra dev
-      - run: uv run pytest --tb=short
+      - run: uv run --frozen pytest --tb=short
 
   test-mobile:
     name: Test Mobile

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -60,14 +60,14 @@ jobs:
 
       # Run database migrations
       # Install from lockfile (supply-chain cooldown baked in) into a venv
-      # inside apps/api, then invoke alembic via `uv run` so the venv is
+      # inside apps/api, then invoke alembic via `uv run --frozen` so the venv is
       # picked up automatically.
       - name: Check pending migrations
         id: migration-check
         working-directory: apps/api
         run: |
           uv sync --frozen --no-dev
-          if uv run alembic check 2>&1 | grep -q "No new upgrade operations detected"; then
+          if uv run --frozen alembic check 2>&1 | grep -q "No new upgrade operations detected"; then
             echo "has_pending=false" >> $GITHUB_OUTPUT
             echo "No pending migrations"
           else
@@ -82,7 +82,7 @@ jobs:
       - name: Run migrations
         if: steps.migration-check.outputs.has_pending == 'true'
         working-directory: apps/api
-        run: uv run alembic upgrade head
+        run: uv run --frozen alembic upgrade head
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           REDIS_URL: "memory://"

--- a/.security/hook-hashes.sha256
+++ b/.security/hook-hashes.sha256
@@ -1,6 +1,6 @@
-a372bfe34e95da56aea69fe789692ec0c3027eac6c29bb967356d939eb7c1480  .claude/hooks/check-uv-install.sh
+208e6485e86ac43fecdc264b6711043aba3d872beecf0e537c0857be28ec2ccb  .claude/hooks/check-uv-install.sh
 ab3e942c6ee38271e51b83b0d881e21e0a4607b4afe3d5cbfdea9308c1304745  .claude/hooks/check-protected-files.sh
 8329945d91a58b298e969d1619e0c525efb9537703060bba71b8a1493ef41fe6  scripts/uv-install.sh
 1b74dda7003ccd2d39981e6f3f85a4f5044d7339e27bc3e068ad4d687b80b6e3  scripts/install-npm-pinned.sh
-4554d5e84aebc74389877f8df2e8d99820d9519000339adcc7b930563deea0e5  scripts/test/test-claude-hooks.sh
+375d054b7514faf30a0769bdcff750ffb854a4dab034f5165affb4e06a9601c8  scripts/test/test-claude-hooks.sh
 bf5661dab74159cc64cd5354ea28e8f83517141f7e5d7ae99027efa5a0491cdc  scripts/test/test-uv-install.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-mobile dev-api dev-ios dev-android dev-both dev-stop lint lint-mobile lint-api test test-mobile test-api e2e e2e-ios e2e-android migrate migrate-new docker-up docker-down docker-reset generate-api-types db-clean-users eval-a eval-b eval-c eval-all api-lock api-install
+.PHONY: dev-mobile dev-api dev-ios dev-android dev-both dev-stop lint lint-mobile lint-api test test-mobile test-api e2e e2e-ios e2e-android migrate migrate-new docker-up docker-down docker-reset generate-api-types db-clean-users eval-a eval-b eval-c eval-all api-lock api-install api-test api-cmd
 
 # Python dependency management (uv-based, with release-age cooldown)
 #
@@ -6,6 +6,12 @@
 #               Use this for environment setup. No network resolution: deps
 #               are restored verbatim from the lockfile, so the supply-chain
 #               cooldown that was applied at lock time is preserved.
+#
+# api-test      Run pytest via uv run --frozen (lockfile is never re-resolved).
+#               Pass extra args: make api-test ARGS="-k test_foo -v"
+#
+# api-cmd       Run an arbitrary command via uv run --frozen.
+#               Example: make api-cmd CMD="ruff check src/"
 #
 # api-lock      Regenerate apps/api/uv.lock with the cooldown applied
 #               (versions younger than UV_COOLDOWN_DAYS days are excluded).
@@ -20,6 +26,13 @@
 # direct `uv pip install` / `uv lock` / `pip install` invocation.
 api-lock:
 	cd apps/api && ../../scripts/uv-install.sh lock
+
+api-test:
+	cd apps/api && uv run --frozen --extra dev pytest $(ARGS)
+
+api-cmd:
+	@if [ -z "$(CMD)" ]; then echo "ERROR: CMD is required. Usage: make api-cmd CMD=\"ruff check src/\""; exit 1; fi
+	cd apps/api && uv run --frozen --extra dev $(CMD)
 
 api-install:
 	@if [ apps/api/pyproject.toml -nt apps/api/uv.lock ]; then \

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -32,21 +32,23 @@ bypass the cooldown:
 - **`.claude/hooks/check-uv-install.sh`** — refuses Bash commands that
   invoke `uv pip install` / `uv pip compile|sync|uninstall`, `uv add`,
   `uv remove`, `uv lock`, `uv sync` (without `--frozen`),
-  `uv tool install|run|upgrade`, `uvx`, or `pip install`. Also refuses
-  `bash -c '...'` / `sh -c '...'` / `eval '...'` / `python -c '...'` when
-  the inner string mentions any of the above. Also refuses Bash file
-  mutations (`chmod`, `rm`, `mv`, `cp`, `sed -i`, `tee`, `ln`, `>`/`>>`)
-  that target any protected file, so the hook cannot be silently disabled
-  by `chmod -x .claude/hooks/check-uv-install.sh`.
+  `uv run` (without `--frozen`), `uv tool install|run|upgrade`, `uvx`,
+  or `pip install`. Also refuses `bash -c '...'` / `sh -c '...'` /
+  `eval '...'` / `python -c '...'` when the inner string mentions any
+  of the above. Also refuses Bash file mutations (`chmod`, `rm`, `mv`,
+  `cp`, `sed -i`, `tee`, `ln`, `>`/`>>`) that target any protected file,
+  so the hook cannot be silently disabled by
+  `chmod -x .claude/hooks/check-uv-install.sh`.
 - **`.claude/hooks/check-protected-files.sh`** — refuses Edit/Write/MultiEdit
   on the files that enforce the policy: `apps/mobile/.npmrc`,
   `scripts/uv-install.sh`, `scripts/install-npm-pinned.sh`, and the two
   hook scripts themselves. Symlink targets are resolved before matching.
 
 The sanctioned entry points are `make api-lock`, `make api-install`,
+`make api-test`, `make api-cmd CMD="..."`,
 `bash scripts/uv-install.sh`, `bash scripts/install-npm-pinned.sh`, and
-the no-resolution uv subcommands (`uv venv`, `uv run`, `uv sync --frozen`,
-`uv --version`).
+the no-resolution uv subcommands (`uv venv`, `uv run --frozen`,
+`uv sync --frozen`, `uv --version`).
 
 > **What these hooks are NOT:** a security boundary against a motivated
 > or compromised actor. Regex over a shell command string cannot reliably

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -115,12 +115,12 @@ cd apps/api
 # --no-dev skips pytest/ruff/etc. which production doesn't need.
 uv sync --frozen --no-dev
 
-# Run migrations against production database via `uv run` (auto-picks up .venv)
+# Run migrations against production database (auto-picks up .venv)
 # NOTE: Use single quotes to avoid shell interpretation of special characters in password
 DATABASE_URL='postgresql+asyncpg://<user>:<password>@<host>:6543/<database>?ssl=require' \
 REDIS_URL='redis://localhost:6379' \
 OPENAI_API_KEY='dummy' \
-uv run alembic upgrade head
+uv run --frozen alembic upgrade head
 ```
 
 ### 2.2 Build and Deploy

--- a/scripts/test/test-claude-hooks.sh
+++ b/scripts/test/test-claude-hooks.sh
@@ -126,6 +126,27 @@ assert_blocked "block: env-var prefix --frozen + uv sync"
 run_bash_hook "uv sync --frozen-mode"
 assert_blocked "block: uv sync --frozen-mode (not standalone token)"
 
+run_bash_hook "uv run pytest"
+assert_blocked "block: uv run without --frozen"
+
+run_bash_hook "uv run --extra dev pytest"
+assert_blocked "block: uv run --extra dev (no --frozen)"
+
+run_bash_hook "cd apps/api && uv run pytest"
+assert_blocked "block: chained uv run without --frozen"
+
+run_bash_hook "uv run ruff check src/"
+assert_blocked "block: uv run ruff (no --frozen)"
+
+run_bash_hook "uv run --refresh # --frozen"
+assert_blocked "block: uv run with --frozen as comment"
+
+run_bash_hook "uv run --frozen-mode pytest"
+assert_blocked "block: uv run --frozen-mode (not standalone token)"
+
+run_bash_hook "FOO=--frozen uv run pytest"
+assert_blocked "block: env-var prefix --frozen + uv run"
+
 run_bash_hook "pip install httpx"
 assert_blocked "block: pip install"
 
@@ -160,6 +181,12 @@ assert_blocked "block: bash -c pip install"
 
 run_bash_hook "bash -c 'uvx ruff'"
 assert_blocked "block: bash -c uvx"
+
+run_bash_hook "bash -c 'uv run pytest'"
+assert_blocked "block: bash -c uv run (indirect)"
+
+run_bash_hook "eval 'uv run --frozen pytest'"
+assert_blocked "block: eval uv run --frozen (indirect, no escape hatch)"
 
 run_bash_hook "eval 'uv pip install evil'"
 assert_blocked "block: eval uv pip install"
@@ -261,8 +288,23 @@ assert_allowed "allow: uv sync --frozen=true"
 run_bash_hook "uv venv"
 assert_allowed "allow: uv venv"
 
-run_bash_hook "uv run pytest"
-assert_allowed "allow: uv run pytest"
+run_bash_hook "uv run --frozen pytest"
+assert_allowed "allow: uv run --frozen pytest"
+
+run_bash_hook "uv run --frozen --extra dev pytest"
+assert_allowed "allow: uv run --frozen --extra dev pytest"
+
+run_bash_hook "cd apps/api && uv run --frozen --extra dev pytest"
+assert_allowed "allow: chained uv run --frozen"
+
+run_bash_hook "uv run --frozen=true pytest"
+assert_allowed "allow: uv run --frozen=true"
+
+run_bash_hook "make api-test"
+assert_allowed "allow: make api-test"
+
+run_bash_hook "make api-cmd CMD='ruff check'"
+assert_allowed "allow: make api-cmd"
 
 run_bash_hook "uv --version"
 assert_allowed "allow: uv --version"


### PR DESCRIPTION
## Summary

- `uv run` without `--frozen` silently re-resolves the lockfile and removes the `exclude-newer` timestamp from `uv.lock`, defeating the supply-chain release-age cooldown
- Extends `.claude/hooks/check-uv-install.sh` to block `uv run` without `--frozen` (same pattern as existing `uv sync` rule)
- Adds `make api-test` and `make api-cmd` Makefile targets as safe wrappers (`uv run --frozen`)
- Adds `--frozen` to all existing `uv run` calls in CI (`ci.yml`), deploy (`deploy-api.yml`), and docs (`DEPLOY.md`)
- Updates `docs/CONTRIB.md` sanctioned commands list
- Adds 15 new hook test cases (9 blocked, 6 allowed) covering direct, chained, indirect, comment-injection, and prefix-attack scenarios

## Test plan

- [x] All 87 hook smoke tests pass (`bash scripts/test/test-claude-hooks.sh`)
- [x] All uv-install wrapper tests pass (`bash scripts/test/test-uv-install.sh`)
- [x] `make api-test ARGS="--co -q"` runs correctly
- [x] Integrity hashes regenerated and verified (`sha256sum -c .security/hook-hashes.sha256`)
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)