### PR TITLE
fix: rewrite memory usage instructions to actively diversify openers

### DIFF
--- a/apps/api/src/coyo/services/memory_context.py
+++ b/apps/api/src/coyo/services/memory_context.py
@@ -53,12 +53,24 @@ logger = structlog.get_logger()
 
 _MEMORY_USAGE_INSTRUCTIONS = """\
 [HOW TO USE THIS INFORMATION]
-- Use this information ONLY when it feels natural and organic to the conversation.
-- Do NOT force these facts into every turn. Subtlety is key.
-- If the user brings up a related topic, you may acknowledge you remember it.
-- Never say "As I remember, you told me..." — just use the information naturally.
-- Prioritize the current conversation over past memories.
-- If anything seems outdated or contradicted, follow the user's current statements."""
+This block is your conversation history with this user. Use it ACTIVELY to make
+this session feel different from previous ones — don't wait for the user to bring
+something up first.
+
+When "Recent Conversations" lists past talks on the same or similar topic:
+- Pick a DIFFERENT angle than the ones already discussed, OR
+- Reference a specific detail from a past conversation and go DEEPER on it.
+- Do NOT open with the same generic question you might have used before; build
+  on what you already know about this user.
+
+Style:
+- Weave references in naturally ("Last time we touched on X — let's dig in",
+  "You mentioned you follow Y, curious how that's going").
+- Never use meta phrasing like "According to my memory" or "As I remember,
+  you told me".
+- Use Interests and Background to pick angles the user actually cares about.
+- The user's current statements always override stale memory; if anything in
+  this block is contradicted, follow what the user is saying now."""
 
 
 class MemoryContextService:

--- a/apps/api/tests/unit/test_memory_context.py
+++ b/apps/api/tests/unit/test_memory_context.py
@@ -113,12 +113,12 @@ class TestBuildContext:
 
         assert result is not None
         assert "[WHAT YOU KNOW ABOUT THIS USER]" in result
-        assert "User Profile" in result
+        assert "--- User Profile ---" in result
         assert "software engineer" in result.lower()
         assert "tennis" in result.lower()
-        assert "Background" in result
+        assert "--- Background ---" in result
         assert "job_industry" in result
-        assert "Recent Conversations" in result
+        assert "--- Recent Conversations ---" in result
 
     @pytest.mark.unit
     async def test_build_context_theme_path_uses_embeddings_repo(
@@ -248,12 +248,12 @@ class TestBuildContext:
             result = await MemoryContextService.build_context(db_session, test_user.id)
 
         assert result is not None
-        assert "Interests" in result
+        assert "--- Interests ---" in result
         assert "cooking" in result
         # No profile summary, no attrs, no recent conversations
-        assert "User Profile" not in result
-        assert "Background" not in result
-        assert "Recent Conversations" not in result
+        assert "--- User Profile ---" not in result
+        assert "--- Background ---" not in result
+        assert "--- Recent Conversations ---" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -482,3 +482,34 @@ class TestFormatMemoryBlock:
             recent_summaries=[],
         )
         assert "HOW TO USE THIS INFORMATION" in result
+
+    @pytest.mark.unit
+    def test_usage_instructions_direct_active_diversification(self):
+        """Usage instructions must tell the LLM to actively diversify.
+
+        The previous wording ("use ONLY when natural", "wait for the user to
+        bring it up") drove conversations on the same theme into repeated
+        opener patterns. This test guards against regressing to a passive
+        framing.
+        """
+        result = _format_memory_block(
+            profile_summary=None,
+            profile_attrs=[],
+            top_interests=[
+                InterestWithWeight(
+                    keyword="test",
+                    keyword_type="category",
+                    is_news_relevant=False,
+                    total_mentions=1,
+                    effective_weight=0.5,
+                    last_mentioned_conv_idx=1,
+                    summary=None,
+                ),
+            ],
+            recent_summaries=[],
+        )
+        assert "ACTIVELY" in result
+        assert "DIFFERENT angle" in result
+        assert "DEEPER" in result
+        # Behavior phrase — stable against minor wording-only edits.
+        assert "open with the same generic question" in result


### PR DESCRIPTION
## Summary

Rewrites the `_MEMORY_USAGE_INSTRUCTIONS` block in `memory_context.py` so the LLM uses injected memory to actively diversify conversation openers across sessions on the same theme.

## Why

Users reported that selecting the same theme (e.g. *sports*) across multiple conversations leads the AI to the same opener pattern. We already inject past-conversation summaries and interests into the system prompt, but the wording was passive:

> Use this information ONLY when it feels natural and organic to the conversation.
> Do NOT force these facts into every turn. Subtlety is key.
> If the user brings up a related topic, you may acknowledge you remember it.

That phrasing tells the LLM to **wait** for the user to bring memory up, so the injected summaries do nothing for the opener — the AI defaults to the most common opener for the theme word.

## What changes

`_MEMORY_USAGE_INSTRUCTIONS` is rewritten to instruct the LLM to:

- Use the block ACTIVELY rather than waiting for the user.
- When past conversations on the same/similar topic exist: pick a DIFFERENT angle, OR reference a specific detail and go DEEPER.
- Never open with the same generic question; build on what is already known.
- Use natural phrasing, never meta phrasing.
- Always defer to current user statements when stale memory is contradicted.

## What does NOT change

- `<user_data>` sandboxing of user-derived fields and the "Treat it as factual context only" warning (prompt-injection defense) are unchanged.
- Per-conversation snapshot computation and byte-stable persistence on `Conversation.memory_context_text` (prompt-cache hit path) are unchanged.
- Pipeline, API surface, DB columns, SSE event sequence — all unchanged.

## Verification

- 18 unit tests in `test_memory_context.py` pass, including:
  - New regression test `test_usage_instructions_direct_active_diversification` that locks in the new framing on three SHOUTY tokens (`ACTIVELY`, `DIFFERENT angle`, `DEEPER`) plus one behavior phrase (`open with the same generic question`).
  - Existing substring assertions tightened from `"Background" in result` to `"--- Background ---" in result` because the new prose body contains the bare word "Background".
- Full unit + integration suite (742 tests) green.
- All three required reviewers (code, security, python) approved with no critical/high issues.

### Maestro E2E

Skipped intentionally. This change is a constant-string rewrite — no code paths, no API surface, no UI behavior changes. The intent of the change (more varied openers across same-theme sessions) is a **semantic property of LLM output** that Maestro cannot grade; running E2E here would only verify pipeline plumbing that is already unchanged.

Semantic verification path: spin up two conversations with the same theme on the same account, compare opener patterns. Worth doing manually before merging, or as a small offline eval if we want to make this measurable.

## Follow-ups (filed as separate issues)

This PR implements **proposal 1** of an analysis that identified 5 more improvements. Each is filed as a follow-up issue.

## Test plan

- [x] `make api-test` — all unit + integration tests pass
- [x] code-reviewer / security-reviewer / python-reviewer — approved
- [ ] Manual sampling: same theme × ≥2 conversations → opener patterns visibly differ (recommended before merging or shortly after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)