### PR TITLE
fix: anchor AI conversation replies on the user's statement

### DIFF
--- a/apps/api/src/coyo/services/turn_orchestrator.py
+++ b/apps/api/src/coyo/services/turn_orchestrator.py
@@ -56,6 +56,14 @@ _CONVERSATION_SYSTEM_PROMPT_PREFIX = """\
 You are a friendly English conversation partner.
 Keep your responses natural, concise (2-3 sentences), and at an intermediate \
 English level.
+Respond to what the user just said, not to the topic in general. Whatever the \
+user tells you — news, results, personal events, opinions, feelings — is true \
+and is your starting point: react to their specific statement with your own \
+impression or an interesting detail, then deepen it with one follow-up that \
+builds on their point rather than a generic question about the topic.
+If they mention a recent event you don't know about, look it up to add detail \
+and color to what they said — never speculate about an outcome they already \
+told you.
 If the user makes a grammar mistake, don't correct them in the conversation — \
 just respond naturally. Corrections are handled separately.
 When you look up information, weave the facts into a natural conversational \

--- a/apps/mobile/e2e/run-e2e.sh
+++ b/apps/mobile/e2e/run-e2e.sh
@@ -37,7 +37,12 @@ init_log "[e2e]"
 init_worktree
 
 MAESTRO_PORT=7001
-MAESTRO_TIMEOUT=420  # 7 minutes (seconds) per maestro test invocation
+MAESTRO_TIMEOUT=600  # 10 minutes (seconds) per maestro test invocation.
+# This is a hang guard (e.g. kAXErrorInvalidUIElement), not a performance
+# assertion — per-step timeouts inside the flows still enforce responsiveness.
+# 420s proved too tight on a loaded Android emulator: the full 8-flow suite
+# needs ~480-500s there (voice-conversation alone takes ~4min with real
+# audio playback), so a healthy run was killed before the last two flows.
 
 # Enable E2E mode: bypasses microphone recording with test audio file
 export E2E_MODE=true


### PR DESCRIPTION
## Summary

Fixes two reported issues with AI responses on the Talk screen:

1. **The AI drifted off the user's statement** — e.g. when the user reported that Sinner *lost* a match, the AI replied with a hypothetical ("If Sinner wins..."), instead of commenting on the stated fact.
2. **The AI was poor at expanding the conversation** — replies were generic empathy with no follow-up grounded in what the user actually said.

### Root cause

The conversation system prompt's only "react + follow-up" instruction was scoped to web lookups ("When you look up information, ..."). On plain turns nothing told the model to engage with the user's utterance, so it anchored on the abstract `Current topic` and produced generic, topic-level moves.

### Fix

Replaced the lookup-scoped instruction with one general principle in the static (cache-safe) prompt prefix:

- Respond to the user's **specific statement**, not the topic in general
- Treat what the user reports (news, results, personal events, opinions, feelings) as **true** and build on it
- React with an impression or detail, then deepen with **one follow-up that builds on their point**
- **Look up** unfamiliar recent events to add detail instead of speculating

Also raises the Maestro E2E suite timeout 420s → 600s (separate commit): a fully passing Android run was killed at 420s; the measured passing suite needs ~480-500s. Per-step timeouts still enforce responsiveness.

### Known tradeoff (intentional)

The model will not fact-check user claims; engagement is prioritized over correction for this conversation-practice UX (flagged informational by security review).

## Test plan

- [x] Reproduced the defect with the old prompt: 0/6 samples produced a follow-up question; replies were generic empathy
- [x] Verified the fix empirically across 4 scenario types (news result, personal event, opinion, emotional disclosure): 14/14 samples react to the stated fact and deepen with a grounded follow-up; web search engages on unknown recent events
- [x] Unit tests: 742 passed (including prompt-prefix cache stability tests)
- [x] Reviews: code-reviewer / security-reviewer / python-reviewer — all approved, no blocking findings
- [x] E2E: iOS PASS (460s), Android PASS (8/8 flows, 498s)
- [x] Manual verification on the Talk screen in dev (user-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)