### PR TITLE
Release: anchor conversation replies on user's statement + E2E timeout fix

### DIFF
--- a/apps/api/src/coyo/services/turn_orchestrator.py
+++ b/apps/api/src/coyo/services/turn_orchestrator.py
@@ -56,6 +56,14 @@ _CONVERSATION_SYSTEM_PROMPT_PREFIX = """\
 You are a friendly English conversation partner.
 Keep your responses natural, concise (2-3 sentences), and at an intermediate \
 English level.
+Respond to what the user just said, not to the topic in general. Whatever the \
+user tells you — news, results, personal events, opinions, feelings — is true \
+and is your starting point: react to their specific statement with your own \
+impression or an interesting detail, then deepen it with one follow-up that \
+builds on their point rather than a generic question about the topic.
+If they mention a recent event you don't know about, look it up to add detail \
+and color to what they said — never speculate about an outcome they already \
+told you.
 If the user makes a grammar mistake, don't correct them in the conversation — \
 just respond naturally. Corrections are handled separately.
 When you look up information, weave the facts into a natural conversational \

--- a/apps/mobile/e2e/run-e2e.sh
+++ b/apps/mobile/e2e/run-e2e.sh
@@ -37,7 +37,12 @@ init_log "[e2e]"
 init_worktree
 
 MAESTRO_PORT=7001
-MAESTRO_TIMEOUT=420  # 7 minutes (seconds) per maestro test invocation
+MAESTRO_TIMEOUT=600  # 10 minutes (seconds) per maestro test invocation.
+# This is a hang guard (e.g. kAXErrorInvalidUIElement), not a performance
+# assertion — per-step timeouts inside the flows still enforce responsiveness.
+# 420s proved too tight on a loaded Android emulator: the full 8-flow suite
+# needs ~480-500s there (voice-conversation alone takes ~4min with real
+# audio playback), so a healthy run was killed before the last two flows.
 
 # Enable E2E mode: bypasses microphone recording with test audio file
 export E2E_MODE=true


### PR DESCRIPTION
## Summary

Promotes `develop` to `main`. Includes the changes merged in PR #197.

### Changes

- **fix: anchor AI conversation replies on the user's statement** (`turn_orchestrator.py`)
  - The conversation system prompt now instructs the AI to react to the user's specific statement (treating it as true) instead of replying generically about the topic
  - Follow-up questions must build on the user's point; unknown recent events are looked up rather than speculated about
- **test: raise Maestro suite timeout from 420s to 600s** (`run-e2e.sh`)
  - 420s was too tight on a loaded Android emulator (full 8-flow suite needs ~480-500s); the timeout is a hang guard, not a performance assertion

## Test plan

- [x] All changes were reviewed and CI-verified in PR #197 before merging to `develop`
- [x] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)